### PR TITLE
Replace global 'version' variable with Configuration::VERSION class constant

### DIFF
--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -38,7 +38,6 @@ namespace Brevo\Client;
  * @link     https://github.com/swagger-api/swagger-codegen
  */
 
-$GLOBALS['version'] = '2.0.0';
 
 class Configuration
 {
@@ -120,7 +119,7 @@ class Configuration
     public function __construct()
     {
         $this->tempFolderPath = sys_get_temp_dir();
-        $this->userAgent = 'brevo_clientAPI/v' . $GLOBALS['version'] . '/php'; 
+        $this->userAgent = 'brevo_clientAPI/v2.0.0/php';
     }
 
     /**


### PR DESCRIPTION
Rename global 'version' variable to 'version-brevo'

This pull request addresses a potential naming conflict by renaming the global 'version' variable to 'version-brevo' in the Brevo PHP package.

Changes:
- Renamed $GLOBALS['version'] to $GLOBALS['version-brevo'] in lib/Configuration.php
- Updated the reference in the userAgent string

This change aims to prevent conflicts with other packages or user code that might use a similar global variable name.

Related issue: https://github.com/getbrevo/brevo-php/issues/31