### PR TITLE
Fix guzzle ^6.5 version (for Ibexa 4.x)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "ext-curl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
-        "guzzlehttp/guzzle": "^7.4.0"
+        "guzzlehttp/guzzle": "^6.5||^7.4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8",


### PR DESCRIPTION
We would like to use this Package in [Ibexa DXP](https://doc.ibexa.co/en/latest/), that require Guzzle 6.5  in it's latest Version.