### PR TITLE
Fix Implicitly marking parameters TransactionalEmailsApi.php on php 8.4

### DIFF
--- a/lib/Api/TransactionalEmailsApi.php
+++ b/lib/Api/TransactionalEmailsApi.php
@@ -70,9 +70,9 @@ class TransactionalEmailsApi
      * @param HeaderSelector  $selector
      */
     public function __construct(
-        ClientInterface $client = null,
-        Configuration $config = null,
-        HeaderSelector $selector = null
+        ?ClientInterface $client = null,
+        ?Configuration $config = null,
+        ?HeaderSelector $selector = null
     ) {
         $this->client = $client ?: new Client();
         $this->config = $config ?: new Configuration();

--- a/lib/Model/SendSmtpEmail.php
+++ b/lib/Model/SendSmtpEmail.php
@@ -250,7 +250,7 @@ class SendSmtpEmail implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['sender'] = isset($data['sender']) ? $data['sender'] : null;
         $this->container['to'] = isset($data['to']) ? $data['to'] : null;

--- a/lib/Model/SendSmtpEmailAttachment.php
+++ b/lib/Model/SendSmtpEmailAttachment.php
@@ -185,7 +185,7 @@ class SendSmtpEmailAttachment implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['url'] = isset($data['url']) ? $data['url'] : null;
         $this->container['content'] = isset($data['content']) ? $data['content'] : null;

--- a/lib/Model/SendSmtpEmailReplyTo.php
+++ b/lib/Model/SendSmtpEmailReplyTo.php
@@ -181,7 +181,7 @@ class SendSmtpEmailReplyTo implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['email'] = isset($data['email']) ? $data['email'] : null;
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;

--- a/lib/Model/SendSmtpEmailSender.php
+++ b/lib/Model/SendSmtpEmailSender.php
@@ -186,7 +186,7 @@ class SendSmtpEmailSender implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
         $this->container['email'] = isset($data['email']) ? $data['email'] : null;

--- a/lib/Model/SendSmtpEmailTo.php
+++ b/lib/Model/SendSmtpEmailTo.php
@@ -180,7 +180,7 @@ class SendSmtpEmailTo implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['email'] = isset($data['email']) ? $data['email'] : null;
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;


### PR DESCRIPTION
On PHP 8.4 when we sent a transactional email, some deprecated messages are log

Message log detail : Deprecated: Brevo\Client\Api\TransactionalEmailsApi::__construct(): Implicitly marking parameter $client as nullable is deprecated, the explicit nullable type must be used instead in /var/www/app/vendor/getbrevo/brevo-php/lib/Api/TransactionalEmailsApi.php on line 72