### PR TITLE
This PR makes the sender name nullable to avoid deprecation errors

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,8 +1,0 @@
-# Default ignored files
-/shelf/
-/workspace.xml
-# Editor-based HTTP Client requests
-/httpRequests/
-# Datasource local storage ignored files
-/dataSources/
-/dataSources.local.xml

--- a/lib/Model/SendSmtpEmailSender.php
+++ b/lib/Model/SendSmtpEmailSender.php
@@ -186,7 +186,7 @@ class SendSmtpEmailSender implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
         $this->container['email'] = isset($data['email']) ? $data['email'] : null;


### PR DESCRIPTION
Deprecated: Brevo\Client\Model\SendSmtpEmailSender::__construct(): Implicitly marking parameter $data as nullable is deprecated, the explicit nullable type must be used instead in /app/vendor/getbrevo/brevo-php/lib/Model/SendSmtpEmailSender.php on line 189