### PR TITLE
Fix: [#76] remove whitespace for php8.3

### DIFF
--- a/lib/Model/GetTransacEmailsListTransactionalEmails.php
+++ b/lib/Model/GetTransacEmailsListTransactionalEmails.php
@@ -1,4 +1,3 @@
-
 <?php
 /**
  * GetTransacEmailsListTransactionalEmails


### PR DESCRIPTION
Fix error 500 on PHP 8.3 on removing the empty ligne.