### PR TITLE
Fix Implicitly marking parameters

### DIFF
--- a/lib/Model/AbTestCampaignResult.php
+++ b/lib/Model/AbTestCampaignResult.php
@@ -246,7 +246,7 @@ class AbTestCampaignResult implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['winningVersion'] = isset($data['winningVersion']) ? $data['winningVersion'] : null;
         $this->container['winningCriteria'] = isset($data['winningCriteria']) ? $data['winningCriteria'] : null;

--- a/lib/Model/AbTestCampaignResultClickedLinks.php
+++ b/lib/Model/AbTestCampaignResultClickedLinks.php
@@ -180,7 +180,7 @@ class AbTestCampaignResultClickedLinks implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['versionA'] = isset($data['versionA']) ? $data['versionA'] : null;
         $this->container['versionB'] = isset($data['versionB']) ? $data['versionB'] : null;

--- a/lib/Model/AbTestCampaignResultStatistics.php
+++ b/lib/Model/AbTestCampaignResultStatistics.php
@@ -200,7 +200,7 @@ class AbTestCampaignResultStatistics implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['openers'] = isset($data['openers']) ? $data['openers'] : null;
         $this->container['clicks'] = isset($data['clicks']) ? $data['clicks'] : null;

--- a/lib/Model/AbTestVersionClicks.php
+++ b/lib/Model/AbTestVersionClicks.php
@@ -176,7 +176,7 @@ class AbTestVersionClicks implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
     }
 

--- a/lib/Model/AbTestVersionClicksInner.php
+++ b/lib/Model/AbTestVersionClicksInner.php
@@ -185,7 +185,7 @@ class AbTestVersionClicksInner implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['link'] = isset($data['link']) ? $data['link'] : null;
         $this->container['clicksCount'] = isset($data['clicksCount']) ? $data['clicksCount'] : null;

--- a/lib/Model/AbTestVersionStats.php
+++ b/lib/Model/AbTestVersionStats.php
@@ -181,7 +181,7 @@ class AbTestVersionStats implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['versionA'] = isset($data['versionA']) ? $data['versionA'] : null;
         $this->container['versionB'] = isset($data['versionB']) ? $data['versionB'] : null;

--- a/lib/Model/AddChildDomain.php
+++ b/lib/Model/AddChildDomain.php
@@ -175,7 +175,7 @@ class AddChildDomain implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['domain'] = isset($data['domain']) ? $data['domain'] : null;
     }

--- a/lib/Model/AddContactToList.php
+++ b/lib/Model/AddContactToList.php
@@ -180,7 +180,7 @@ class AddContactToList implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['emails'] = isset($data['emails']) ? $data['emails'] : null;
         $this->container['ids'] = isset($data['ids']) ? $data['ids'] : null;

--- a/lib/Model/AddCredits.php
+++ b/lib/Model/AddCredits.php
@@ -180,7 +180,7 @@ class AddCredits implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['sms'] = isset($data['sms']) ? $data['sms'] : null;
         $this->container['email'] = isset($data['email']) ? $data['email'] : null;

--- a/lib/Model/AllOfgetContactsContactsItems.php
+++ b/lib/Model/AllOfgetContactsContactsItems.php
@@ -159,7 +159,7 @@ class AllOfgetContactsContactsItems extends GetContactDetails
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         parent::__construct($data);
 

--- a/lib/Model/AllOfgetEmailCampaignsCampaignsItems.php
+++ b/lib/Model/AllOfgetEmailCampaignsCampaignsItems.php
@@ -174,7 +174,7 @@ class AllOfgetEmailCampaignsCampaignsItems extends GetExtendedCampaignOverview
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         parent::__construct($data);
 

--- a/lib/Model/AuthenticateDomainModel.php
+++ b/lib/Model/AuthenticateDomainModel.php
@@ -180,7 +180,7 @@ class AuthenticateDomainModel implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['domainName'] = isset($data['domainName']) ? $data['domainName'] : null;
         $this->container['message'] = isset($data['message']) ? $data['message'] : null;

--- a/lib/Model/BlockDomain.php
+++ b/lib/Model/BlockDomain.php
@@ -175,7 +175,7 @@ class BlockDomain implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['domain'] = isset($data['domain']) ? $data['domain'] : null;
     }

--- a/lib/Model/Body.php
+++ b/lib/Model/Body.php
@@ -180,7 +180,7 @@ class Body implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['groupName'] = isset($data['groupName']) ? $data['groupName'] : null;
         $this->container['subAccountIds'] = isset($data['subAccountIds']) ? $data['subAccountIds'] : null;

--- a/lib/Model/Body1.php
+++ b/lib/Model/Body1.php
@@ -180,7 +180,7 @@ class Body1 implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['groupName'] = isset($data['groupName']) ? $data['groupName'] : null;
         $this->container['subAccountIds'] = isset($data['subAccountIds']) ? $data['subAccountIds'] : null;

--- a/lib/Model/Body10.php
+++ b/lib/Model/Body10.php
@@ -200,7 +200,7 @@ class Body10 implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['visitorId'] = isset($data['visitorId']) ? $data['visitorId'] : null;
         $this->container['text'] = isset($data['text']) ? $data['text'] : null;

--- a/lib/Model/Body11.php
+++ b/lib/Model/Body11.php
@@ -175,7 +175,7 @@ class Body11 implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['text'] = isset($data['text']) ? $data['text'] : null;
     }

--- a/lib/Model/Body12.php
+++ b/lib/Model/Body12.php
@@ -190,7 +190,7 @@ class Body12 implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['visitorId'] = isset($data['visitorId']) ? $data['visitorId'] : null;
         $this->container['text'] = isset($data['text']) ? $data['text'] : null;

--- a/lib/Model/Body13.php
+++ b/lib/Model/Body13.php
@@ -175,7 +175,7 @@ class Body13 implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['text'] = isset($data['text']) ? $data['text'] : null;
     }

--- a/lib/Model/Body14.php
+++ b/lib/Model/Body14.php
@@ -190,7 +190,7 @@ class Body14 implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['agentId'] = isset($data['agentId']) ? $data['agentId'] : null;
         $this->container['receivedFrom'] = isset($data['receivedFrom']) ? $data['receivedFrom'] : null;

--- a/lib/Model/Body2.php
+++ b/lib/Model/Body2.php
@@ -185,7 +185,7 @@ class Body2 implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
         $this->container['attributes'] = isset($data['attributes']) ? $data['attributes'] : null;

--- a/lib/Model/Body3.php
+++ b/lib/Model/Body3.php
@@ -185,7 +185,7 @@ class Body3 implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
         $this->container['attributes'] = isset($data['attributes']) ? $data['attributes'] : null;

--- a/lib/Model/Body4.php
+++ b/lib/Model/Body4.php
@@ -190,7 +190,7 @@ class Body4 implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['linkContactIds'] = isset($data['linkContactIds']) ? $data['linkContactIds'] : null;
         $this->container['unlinkContactIds'] = isset($data['unlinkContactIds']) ? $data['unlinkContactIds'] : null;

--- a/lib/Model/Body5.php
+++ b/lib/Model/Body5.php
@@ -180,7 +180,7 @@ class Body5 implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
         $this->container['attributes'] = isset($data['attributes']) ? $data['attributes'] : null;

--- a/lib/Model/Body6.php
+++ b/lib/Model/Body6.php
@@ -180,7 +180,7 @@ class Body6 implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
         $this->container['attributes'] = isset($data['attributes']) ? $data['attributes'] : null;

--- a/lib/Model/Body7.php
+++ b/lib/Model/Body7.php
@@ -190,7 +190,7 @@ class Body7 implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['linkContactIds'] = isset($data['linkContactIds']) ? $data['linkContactIds'] : null;
         $this->container['unlinkContactIds'] = isset($data['unlinkContactIds']) ? $data['unlinkContactIds'] : null;

--- a/lib/Model/Body8.php
+++ b/lib/Model/Body8.php
@@ -225,7 +225,7 @@ class Body8 implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
         $this->container['duration'] = isset($data['duration']) ? $data['duration'] : null;

--- a/lib/Model/Body9.php
+++ b/lib/Model/Body9.php
@@ -220,7 +220,7 @@ class Body9 implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
         $this->container['duration'] = isset($data['duration']) ? $data['duration'] : null;

--- a/lib/Model/BodyVariablesItems.php
+++ b/lib/Model/BodyVariablesItems.php
@@ -175,7 +175,7 @@ class BodyVariablesItems implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
     }
 

--- a/lib/Model/CompaniesList.php
+++ b/lib/Model/CompaniesList.php
@@ -176,7 +176,7 @@ class CompaniesList implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['items'] = isset($data['items']) ? $data['items'] : null;
     }

--- a/lib/Model/Company.php
+++ b/lib/Model/Company.php
@@ -191,7 +191,7 @@ class Company implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['attributes'] = isset($data['attributes']) ? $data['attributes'] : null;

--- a/lib/Model/CompanyAttributes.php
+++ b/lib/Model/CompanyAttributes.php
@@ -176,7 +176,7 @@ class CompanyAttributes implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
     }
 

--- a/lib/Model/CompanyAttributesInner.php
+++ b/lib/Model/CompanyAttributesInner.php
@@ -196,7 +196,7 @@ class CompanyAttributesInner implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['internalName'] = isset($data['internalName']) ? $data['internalName'] : null;
         $this->container['label'] = isset($data['label']) ? $data['label'] : null;

--- a/lib/Model/ComponentItems.php
+++ b/lib/Model/ComponentItems.php
@@ -180,7 +180,7 @@ class ComponentItems implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['type'] = isset($data['type']) ? $data['type'] : null;
         $this->container['text'] = isset($data['text']) ? $data['text'] : null;

--- a/lib/Model/Contact.php
+++ b/lib/Model/Contact.php
@@ -211,7 +211,7 @@ class Contact implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['virtualNextTask'] = isset($data['virtualNextTask']) ? $data['virtualNextTask'] : null;
         $this->container['email'] = isset($data['email']) ? $data['email'] : null;

--- a/lib/Model/ContactErrorModel.php
+++ b/lib/Model/ContactErrorModel.php
@@ -206,7 +206,7 @@ class ContactErrorModel implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['code'] = isset($data['code']) ? $data['code'] : null;
         $this->container['message'] = isset($data['message']) ? $data['message'] : null;

--- a/lib/Model/ConversationsMessage.php
+++ b/lib/Model/ConversationsMessage.php
@@ -236,7 +236,7 @@ class ConversationsMessage implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['type'] = isset($data['type']) ? $data['type'] : null;

--- a/lib/Model/ConversationsMessageFile.php
+++ b/lib/Model/ConversationsMessageFile.php
@@ -195,7 +195,7 @@ class ConversationsMessageFile implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['filename'] = isset($data['filename']) ? $data['filename'] : null;
         $this->container['size'] = isset($data['size']) ? $data['size'] : null;

--- a/lib/Model/ConversationsMessageFileImageInfo.php
+++ b/lib/Model/ConversationsMessageFileImageInfo.php
@@ -186,7 +186,7 @@ class ConversationsMessageFileImageInfo implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['width'] = isset($data['width']) ? $data['width'] : null;
         $this->container['height'] = isset($data['height']) ? $data['height'] : null;

--- a/lib/Model/CreateApiKeyRequest.php
+++ b/lib/Model/CreateApiKeyRequest.php
@@ -180,7 +180,7 @@ class CreateApiKeyRequest implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;

--- a/lib/Model/CreateApiKeyResponse.php
+++ b/lib/Model/CreateApiKeyResponse.php
@@ -180,7 +180,7 @@ class CreateApiKeyResponse implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['status'] = isset($data['status']) ? $data['status'] : null;
         $this->container['key'] = isset($data['key']) ? $data['key'] : null;

--- a/lib/Model/CreateAttribute.php
+++ b/lib/Model/CreateAttribute.php
@@ -220,7 +220,7 @@ class CreateAttribute implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['value'] = isset($data['value']) ? $data['value'] : null;
         $this->container['isRecurring'] = isset($data['isRecurring']) ? $data['isRecurring'] : null;

--- a/lib/Model/CreateAttributeEnumeration.php
+++ b/lib/Model/CreateAttributeEnumeration.php
@@ -180,7 +180,7 @@ class CreateAttributeEnumeration implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['value'] = isset($data['value']) ? $data['value'] : null;
         $this->container['label'] = isset($data['label']) ? $data['label'] : null;

--- a/lib/Model/CreateCategoryModel.php
+++ b/lib/Model/CreateCategoryModel.php
@@ -175,7 +175,7 @@ class CreateCategoryModel implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
     }

--- a/lib/Model/CreateChild.php
+++ b/lib/Model/CreateChild.php
@@ -223,7 +223,7 @@ class CreateChild implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['email'] = isset($data['email']) ? $data['email'] : null;
         $this->container['firstName'] = isset($data['firstName']) ? $data['firstName'] : null;

--- a/lib/Model/CreateContact.php
+++ b/lib/Model/CreateContact.php
@@ -207,7 +207,7 @@ class CreateContact implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['email'] = isset($data['email']) ? $data['email'] : null;
         $this->container['extId'] = isset($data['extId']) ? $data['extId'] : null;

--- a/lib/Model/CreateCouponCollection.php
+++ b/lib/Model/CreateCouponCollection.php
@@ -180,7 +180,7 @@ class CreateCouponCollection implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
         $this->container['defaultCoupon'] = isset($data['defaultCoupon']) ? $data['defaultCoupon'] : null;

--- a/lib/Model/CreateCoupons.php
+++ b/lib/Model/CreateCoupons.php
@@ -180,7 +180,7 @@ class CreateCoupons implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['collectionId'] = isset($data['collectionId']) ? $data['collectionId'] : null;
         $this->container['coupons'] = isset($data['coupons']) ? $data['coupons'] : null;

--- a/lib/Model/CreateDoiContact.php
+++ b/lib/Model/CreateDoiContact.php
@@ -200,7 +200,7 @@ class CreateDoiContact implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['email'] = isset($data['email']) ? $data['email'] : null;
         $this->container['attributes'] = isset($data['attributes']) ? $data['attributes'] : null;

--- a/lib/Model/CreateDomain.php
+++ b/lib/Model/CreateDomain.php
@@ -175,7 +175,7 @@ class CreateDomain implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
     }

--- a/lib/Model/CreateDomainModel.php
+++ b/lib/Model/CreateDomainModel.php
@@ -190,7 +190,7 @@ class CreateDomainModel implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['domainName'] = isset($data['domainName']) ? $data['domainName'] : null;

--- a/lib/Model/CreateDomainModelDnsRecords.php
+++ b/lib/Model/CreateDomainModelDnsRecords.php
@@ -180,7 +180,7 @@ class CreateDomainModelDnsRecords implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['dkimRecord'] = isset($data['dkimRecord']) ? $data['dkimRecord'] : null;
         $this->container['brevoCode'] = isset($data['brevoCode']) ? $data['brevoCode'] : null;

--- a/lib/Model/CreateDomainModelDnsRecordsDkimRecord.php
+++ b/lib/Model/CreateDomainModelDnsRecordsDkimRecord.php
@@ -190,7 +190,7 @@ class CreateDomainModelDnsRecordsDkimRecord implements ModelInterface, ArrayAcce
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['type'] = isset($data['type']) ? $data['type'] : null;
         $this->container['value'] = isset($data['value']) ? $data['value'] : null;

--- a/lib/Model/CreateEmailCampaign.php
+++ b/lib/Model/CreateEmailCampaign.php
@@ -340,7 +340,7 @@ class CreateEmailCampaign implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['tag'] = isset($data['tag']) ? $data['tag'] : null;
         $this->container['sender'] = isset($data['sender']) ? $data['sender'] : null;

--- a/lib/Model/CreateEmailCampaignRecipients.php
+++ b/lib/Model/CreateEmailCampaignRecipients.php
@@ -186,7 +186,7 @@ class CreateEmailCampaignRecipients implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['exclusionListIds'] = isset($data['exclusionListIds']) ? $data['exclusionListIds'] : null;
         $this->container['listIds'] = isset($data['listIds']) ? $data['listIds'] : null;

--- a/lib/Model/CreateEmailCampaignSender.php
+++ b/lib/Model/CreateEmailCampaignSender.php
@@ -186,7 +186,7 @@ class CreateEmailCampaignSender implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
         $this->container['email'] = isset($data['email']) ? $data['email'] : null;

--- a/lib/Model/CreateExternalFeed.php
+++ b/lib/Model/CreateExternalFeed.php
@@ -232,7 +232,7 @@ class CreateExternalFeed implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
         $this->container['url'] = isset($data['url']) ? $data['url'] : null;

--- a/lib/Model/CreateList.php
+++ b/lib/Model/CreateList.php
@@ -177,7 +177,7 @@ class CreateList implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
         $this->container['folderId'] = isset($data['folderId']) ? $data['folderId'] : null;

--- a/lib/Model/CreateModel.php
+++ b/lib/Model/CreateModel.php
@@ -175,7 +175,7 @@ class CreateModel implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
     }

--- a/lib/Model/CreateProductModel.php
+++ b/lib/Model/CreateProductModel.php
@@ -175,7 +175,7 @@ class CreateProductModel implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
     }

--- a/lib/Model/CreateReseller.php
+++ b/lib/Model/CreateReseller.php
@@ -180,7 +180,7 @@ class CreateReseller implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['authKey'] = isset($data['authKey']) ? $data['authKey'] : null;
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;

--- a/lib/Model/CreateSender.php
+++ b/lib/Model/CreateSender.php
@@ -185,7 +185,7 @@ class CreateSender implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
         $this->container['email'] = isset($data['email']) ? $data['email'] : null;

--- a/lib/Model/CreateSenderIps.php
+++ b/lib/Model/CreateSenderIps.php
@@ -185,7 +185,7 @@ class CreateSenderIps implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['ip'] = isset($data['ip']) ? $data['ip'] : null;
         $this->container['domain'] = isset($data['domain']) ? $data['domain'] : null;

--- a/lib/Model/CreateSenderModel.php
+++ b/lib/Model/CreateSenderModel.php
@@ -185,7 +185,7 @@ class CreateSenderModel implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['spfError'] = isset($data['spfError']) ? $data['spfError'] : null;

--- a/lib/Model/CreateSmsCampaign.php
+++ b/lib/Model/CreateSmsCampaign.php
@@ -210,7 +210,7 @@ class CreateSmsCampaign implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
         $this->container['sender'] = isset($data['sender']) ? $data['sender'] : null;

--- a/lib/Model/CreateSmsCampaignRecipients.php
+++ b/lib/Model/CreateSmsCampaignRecipients.php
@@ -180,7 +180,7 @@ class CreateSmsCampaignRecipients implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['listIds'] = isset($data['listIds']) ? $data['listIds'] : null;
         $this->container['exclusionListIds'] = isset($data['exclusionListIds']) ? $data['exclusionListIds'] : null;

--- a/lib/Model/CreateSmtpEmail.php
+++ b/lib/Model/CreateSmtpEmail.php
@@ -180,7 +180,7 @@ class CreateSmtpEmail implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['messageId'] = isset($data['messageId']) ? $data['messageId'] : null;
         $this->container['messageIds'] = isset($data['messageIds']) ? $data['messageIds'] : null;

--- a/lib/Model/CreateSmtpTemplate.php
+++ b/lib/Model/CreateSmtpTemplate.php
@@ -220,7 +220,7 @@ class CreateSmtpTemplate implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['tag'] = isset($data['tag']) ? $data['tag'] : null;
         $this->container['sender'] = isset($data['sender']) ? $data['sender'] : null;

--- a/lib/Model/CreateSmtpTemplateSender.php
+++ b/lib/Model/CreateSmtpTemplateSender.php
@@ -186,7 +186,7 @@ class CreateSmtpTemplateSender implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
         $this->container['email'] = isset($data['email']) ? $data['email'] : null;

--- a/lib/Model/CreateSubAccount.php
+++ b/lib/Model/CreateSubAccount.php
@@ -213,7 +213,7 @@ class CreateSubAccount implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['companyName'] = isset($data['companyName']) ? $data['companyName'] : null;
         $this->container['email'] = isset($data['email']) ? $data['email'] : null;

--- a/lib/Model/CreateSubAccountResponse.php
+++ b/lib/Model/CreateSubAccountResponse.php
@@ -175,7 +175,7 @@ class CreateSubAccountResponse implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
     }

--- a/lib/Model/CreateUpdateBatchCategory.php
+++ b/lib/Model/CreateUpdateBatchCategory.php
@@ -180,7 +180,7 @@ class CreateUpdateBatchCategory implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['categories'] = isset($data['categories']) ? $data['categories'] : null;
         $this->container['updateEnabled'] = isset($data['updateEnabled']) ? $data['updateEnabled'] : null;

--- a/lib/Model/CreateUpdateBatchCategoryModel.php
+++ b/lib/Model/CreateUpdateBatchCategoryModel.php
@@ -180,7 +180,7 @@ class CreateUpdateBatchCategoryModel implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['createdCount'] = isset($data['createdCount']) ? $data['createdCount'] : null;
         $this->container['updatedCount'] = isset($data['updatedCount']) ? $data['updatedCount'] : null;

--- a/lib/Model/CreateUpdateBatchProducts.php
+++ b/lib/Model/CreateUpdateBatchProducts.php
@@ -180,7 +180,7 @@ class CreateUpdateBatchProducts implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['products'] = isset($data['products']) ? $data['products'] : null;
         $this->container['updateEnabled'] = isset($data['updateEnabled']) ? $data['updateEnabled'] : null;

--- a/lib/Model/CreateUpdateBatchProductsModel.php
+++ b/lib/Model/CreateUpdateBatchProductsModel.php
@@ -180,7 +180,7 @@ class CreateUpdateBatchProductsModel implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['createdCount'] = isset($data['createdCount']) ? $data['createdCount'] : null;
         $this->container['updatedCount'] = isset($data['updatedCount']) ? $data['updatedCount'] : null;

--- a/lib/Model/CreateUpdateCategories.php
+++ b/lib/Model/CreateUpdateCategories.php
@@ -190,7 +190,7 @@ class CreateUpdateCategories implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;

--- a/lib/Model/CreateUpdateCategory.php
+++ b/lib/Model/CreateUpdateCategory.php
@@ -195,7 +195,7 @@ class CreateUpdateCategory implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;

--- a/lib/Model/CreateUpdateContactModel.php
+++ b/lib/Model/CreateUpdateContactModel.php
@@ -175,7 +175,7 @@ class CreateUpdateContactModel implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
     }

--- a/lib/Model/CreateUpdateFolder.php
+++ b/lib/Model/CreateUpdateFolder.php
@@ -172,7 +172,7 @@ class CreateUpdateFolder implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
     }

--- a/lib/Model/CreateUpdateProduct.php
+++ b/lib/Model/CreateUpdateProduct.php
@@ -225,7 +225,7 @@ class CreateUpdateProduct implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;

--- a/lib/Model/CreateUpdateProducts.php
+++ b/lib/Model/CreateUpdateProducts.php
@@ -220,7 +220,7 @@ class CreateUpdateProducts implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;

--- a/lib/Model/CreateWebhook.php
+++ b/lib/Model/CreateWebhook.php
@@ -272,7 +272,7 @@ class CreateWebhook implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['url'] = isset($data['url']) ? $data['url'] : null;
         $this->container['description'] = isset($data['description']) ? $data['description'] : null;

--- a/lib/Model/CreateWhatsAppCampaign.php
+++ b/lib/Model/CreateWhatsAppCampaign.php
@@ -190,7 +190,7 @@ class CreateWhatsAppCampaign implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
         $this->container['templateId'] = isset($data['templateId']) ? $data['templateId'] : null;

--- a/lib/Model/CreateWhatsAppCampaignRecipients.php
+++ b/lib/Model/CreateWhatsAppCampaignRecipients.php
@@ -186,7 +186,7 @@ class CreateWhatsAppCampaignRecipients implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['excludedListIds'] = isset($data['excludedListIds']) ? $data['excludedListIds'] : null;
         $this->container['listIds'] = isset($data['listIds']) ? $data['listIds'] : null;

--- a/lib/Model/CreateWhatsAppTemplate.php
+++ b/lib/Model/CreateWhatsAppTemplate.php
@@ -235,7 +235,7 @@ class CreateWhatsAppTemplate implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
         $this->container['language'] = isset($data['language']) ? $data['language'] : null;

--- a/lib/Model/CreatedBatchId.php
+++ b/lib/Model/CreatedBatchId.php
@@ -175,7 +175,7 @@ class CreatedBatchId implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['batchId'] = isset($data['batchId']) ? $data['batchId'] : null;
     }

--- a/lib/Model/CreatedProcessId.php
+++ b/lib/Model/CreatedProcessId.php
@@ -175,7 +175,7 @@ class CreatedProcessId implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['processId'] = isset($data['processId']) ? $data['processId'] : null;
     }

--- a/lib/Model/Deal.php
+++ b/lib/Model/Deal.php
@@ -191,7 +191,7 @@ class Deal implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['attributes'] = isset($data['attributes']) ? $data['attributes'] : null;

--- a/lib/Model/DealAttributes.php
+++ b/lib/Model/DealAttributes.php
@@ -176,7 +176,7 @@ class DealAttributes implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
     }
 

--- a/lib/Model/DealAttributesInner.php
+++ b/lib/Model/DealAttributesInner.php
@@ -196,7 +196,7 @@ class DealAttributesInner implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['internalName'] = isset($data['internalName']) ? $data['internalName'] : null;
         $this->container['label'] = isset($data['label']) ? $data['label'] : null;

--- a/lib/Model/DealsList.php
+++ b/lib/Model/DealsList.php
@@ -176,7 +176,7 @@ class DealsList implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['items'] = isset($data['items']) ? $data['items'] : null;
     }

--- a/lib/Model/DeleteHardbounces.php
+++ b/lib/Model/DeleteHardbounces.php
@@ -185,7 +185,7 @@ class DeleteHardbounces implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['startDate'] = isset($data['startDate']) ? $data['startDate'] : null;
         $this->container['endDate'] = isset($data['endDate']) ? $data['endDate'] : null;

--- a/lib/Model/EmailExportRecipients.php
+++ b/lib/Model/EmailExportRecipients.php
@@ -207,7 +207,7 @@ class EmailExportRecipients implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['notifyURL'] = isset($data['notifyURL']) ? $data['notifyURL'] : null;
         $this->container['recipientsType'] = isset($data['recipientsType']) ? $data['recipientsType'] : null;

--- a/lib/Model/Event.php
+++ b/lib/Model/Event.php
@@ -195,7 +195,7 @@ class Event implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['eventName'] = isset($data['eventName']) ? $data['eventName'] : null;
         $this->container['eventDate'] = isset($data['eventDate']) ? $data['eventDate'] : null;

--- a/lib/Model/EventIdentifiers.php
+++ b/lib/Model/EventIdentifiers.php
@@ -196,7 +196,7 @@ class EventIdentifiers implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['emailId'] = isset($data['emailId']) ? $data['emailId'] : null;
         $this->container['phoneId'] = isset($data['phoneId']) ? $data['phoneId'] : null;

--- a/lib/Model/ExportWebhooksHistory.php
+++ b/lib/Model/ExportWebhooksHistory.php
@@ -280,7 +280,7 @@ class ExportWebhooksHistory implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['days'] = isset($data['days']) ? $data['days'] : null;
         $this->container['startDate'] = isset($data['startDate']) ? $data['startDate'] : null;

--- a/lib/Model/FileData.php
+++ b/lib/Model/FileData.php
@@ -226,7 +226,7 @@ class FileData implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['url'] = isset($data['url']) ? $data['url'] : null;
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;

--- a/lib/Model/FileDownloadableLink.php
+++ b/lib/Model/FileDownloadableLink.php
@@ -175,7 +175,7 @@ class FileDownloadableLink implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['fileUrl'] = isset($data['fileUrl']) ? $data['fileUrl'] : null;
     }

--- a/lib/Model/FileList.php
+++ b/lib/Model/FileList.php
@@ -176,7 +176,7 @@ class FileList implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
     }
 

--- a/lib/Model/GetAccount.php
+++ b/lib/Model/GetAccount.php
@@ -177,7 +177,7 @@ class GetAccount extends GetExtendedClient
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         parent::__construct($data);
 

--- a/lib/Model/GetAccountActivity.php
+++ b/lib/Model/GetAccountActivity.php
@@ -175,7 +175,7 @@ class GetAccountActivity implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['logs'] = isset($data['logs']) ? $data['logs'] : null;
     }

--- a/lib/Model/GetAccountActivityLogs.php
+++ b/lib/Model/GetAccountActivityLogs.php
@@ -195,7 +195,7 @@ class GetAccountActivityLogs implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['action'] = isset($data['action']) ? $data['action'] : null;
         $this->container['date'] = isset($data['date']) ? $data['date'] : null;

--- a/lib/Model/GetAccountMarketingAutomation.php
+++ b/lib/Model/GetAccountMarketingAutomation.php
@@ -180,7 +180,7 @@ class GetAccountMarketingAutomation implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['key'] = isset($data['key']) ? $data['key'] : null;
         $this->container['enabled'] = isset($data['enabled']) ? $data['enabled'] : null;

--- a/lib/Model/GetAccountPlan.php
+++ b/lib/Model/GetAccountPlan.php
@@ -234,7 +234,7 @@ class GetAccountPlan implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['type'] = isset($data['type']) ? $data['type'] : null;
         $this->container['creditsType'] = isset($data['creditsType']) ? $data['creditsType'] : null;

--- a/lib/Model/GetAccountRelay.php
+++ b/lib/Model/GetAccountRelay.php
@@ -181,7 +181,7 @@ class GetAccountRelay implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['enabled'] = isset($data['enabled']) ? $data['enabled'] : null;
         $this->container['data'] = isset($data['data']) ? $data['data'] : null;

--- a/lib/Model/GetAccountRelayData.php
+++ b/lib/Model/GetAccountRelayData.php
@@ -186,7 +186,7 @@ class GetAccountRelayData implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['userName'] = isset($data['userName']) ? $data['userName'] : null;
         $this->container['relay'] = isset($data['relay']) ? $data['relay'] : null;

--- a/lib/Model/GetAggregatedReport.php
+++ b/lib/Model/GetAggregatedReport.php
@@ -235,7 +235,7 @@ class GetAggregatedReport implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['range'] = isset($data['range']) ? $data['range'] : null;
         $this->container['requests'] = isset($data['requests']) ? $data['requests'] : null;

--- a/lib/Model/GetAllExternalFeeds.php
+++ b/lib/Model/GetAllExternalFeeds.php
@@ -180,7 +180,7 @@ class GetAllExternalFeeds implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['count'] = isset($data['count']) ? $data['count'] : null;
         $this->container['feeds'] = isset($data['feeds']) ? $data['feeds'] : null;

--- a/lib/Model/GetAllExternalFeedsFeeds.php
+++ b/lib/Model/GetAllExternalFeedsFeeds.php
@@ -247,7 +247,7 @@ class GetAllExternalFeedsFeeds implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;

--- a/lib/Model/GetAttributes.php
+++ b/lib/Model/GetAttributes.php
@@ -172,7 +172,7 @@ class GetAttributes implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['attributes'] = isset($data['attributes']) ? $data['attributes'] : null;
     }

--- a/lib/Model/GetAttributesAttributes.php
+++ b/lib/Model/GetAttributesAttributes.php
@@ -237,7 +237,7 @@ class GetAttributesAttributes implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
         $this->container['category'] = isset($data['category']) ? $data['category'] : null;

--- a/lib/Model/GetAttributesEnumeration.php
+++ b/lib/Model/GetAttributesEnumeration.php
@@ -180,7 +180,7 @@ class GetAttributesEnumeration implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['value'] = isset($data['value']) ? $data['value'] : null;
         $this->container['label'] = isset($data['label']) ? $data['label'] : null;

--- a/lib/Model/GetBlockedDomains.php
+++ b/lib/Model/GetBlockedDomains.php
@@ -176,7 +176,7 @@ class GetBlockedDomains implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['domains'] = isset($data['domains']) ? $data['domains'] : null;
     }

--- a/lib/Model/GetCampaignOverview.php
+++ b/lib/Model/GetCampaignOverview.php
@@ -278,7 +278,7 @@ class GetCampaignOverview implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;

--- a/lib/Model/GetCampaignRecipients.php
+++ b/lib/Model/GetCampaignRecipients.php
@@ -180,7 +180,7 @@ class GetCampaignRecipients implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['lists'] = isset($data['lists']) ? $data['lists'] : null;
         $this->container['exclusionLists'] = isset($data['exclusionLists']) ? $data['exclusionLists'] : null;

--- a/lib/Model/GetCampaignStats.php
+++ b/lib/Model/GetCampaignStats.php
@@ -252,7 +252,7 @@ class GetCampaignStats implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['listId'] = isset($data['listId']) ? $data['listId'] : null;
         $this->container['uniqueClicks'] = isset($data['uniqueClicks']) ? $data['uniqueClicks'] : null;

--- a/lib/Model/GetCategories.php
+++ b/lib/Model/GetCategories.php
@@ -180,7 +180,7 @@ class GetCategories implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['categories'] = isset($data['categories']) ? $data['categories'] : null;
         $this->container['count'] = isset($data['count']) ? $data['count'] : null;

--- a/lib/Model/GetCategoryDetails.php
+++ b/lib/Model/GetCategoryDetails.php
@@ -200,7 +200,7 @@ class GetCategoryDetails implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;

--- a/lib/Model/GetChildAccountCreationStatus.php
+++ b/lib/Model/GetChildAccountCreationStatus.php
@@ -175,7 +175,7 @@ class GetChildAccountCreationStatus implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['childAccountCreated'] = isset($data['childAccountCreated']) ? $data['childAccountCreated'] : null;
     }

--- a/lib/Model/GetChildDomain.php
+++ b/lib/Model/GetChildDomain.php
@@ -180,7 +180,7 @@ class GetChildDomain implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['domain'] = isset($data['domain']) ? $data['domain'] : null;
         $this->container['active'] = isset($data['active']) ? $data['active'] : null;

--- a/lib/Model/GetChildDomains.php
+++ b/lib/Model/GetChildDomains.php
@@ -175,7 +175,7 @@ class GetChildDomains implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
     }
 

--- a/lib/Model/GetChildInfo.php
+++ b/lib/Model/GetChildInfo.php
@@ -187,7 +187,7 @@ class GetChildInfo extends GetClient
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         parent::__construct($data);
 

--- a/lib/Model/GetChildInfoApiKeys.php
+++ b/lib/Model/GetChildInfoApiKeys.php
@@ -181,7 +181,7 @@ class GetChildInfoApiKeys implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['v2'] = isset($data['v2']) ? $data['v2'] : null;
         $this->container['v3'] = isset($data['v3']) ? $data['v3'] : null;

--- a/lib/Model/GetChildInfoApiKeysV2.php
+++ b/lib/Model/GetChildInfoApiKeysV2.php
@@ -180,7 +180,7 @@ class GetChildInfoApiKeysV2 implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
         $this->container['key'] = isset($data['key']) ? $data['key'] : null;

--- a/lib/Model/GetChildInfoApiKeysV3.php
+++ b/lib/Model/GetChildInfoApiKeysV3.php
@@ -180,7 +180,7 @@ class GetChildInfoApiKeysV3 implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
         $this->container['key'] = isset($data['key']) ? $data['key'] : null;

--- a/lib/Model/GetChildInfoCredits.php
+++ b/lib/Model/GetChildInfoCredits.php
@@ -181,7 +181,7 @@ class GetChildInfoCredits implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['emailCredits'] = isset($data['emailCredits']) ? $data['emailCredits'] : null;
         $this->container['smsCredits'] = isset($data['smsCredits']) ? $data['smsCredits'] : null;

--- a/lib/Model/GetChildInfoStatistics.php
+++ b/lib/Model/GetChildInfoStatistics.php
@@ -186,7 +186,7 @@ class GetChildInfoStatistics implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['previousMonthTotalSent'] = isset($data['previousMonthTotalSent']) ? $data['previousMonthTotalSent'] : null;
         $this->container['currentMonthTotalSent'] = isset($data['currentMonthTotalSent']) ? $data['currentMonthTotalSent'] : null;

--- a/lib/Model/GetChildrenList.php
+++ b/lib/Model/GetChildrenList.php
@@ -180,7 +180,7 @@ class GetChildrenList implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['children'] = isset($data['children']) ? $data['children'] : null;
         $this->container['count'] = isset($data['count']) ? $data['count'] : null;

--- a/lib/Model/GetClient.php
+++ b/lib/Model/GetClient.php
@@ -190,7 +190,7 @@ class GetClient implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['email'] = isset($data['email']) ? $data['email'] : null;
         $this->container['firstName'] = isset($data['firstName']) ? $data['firstName'] : null;

--- a/lib/Model/GetContactCampaignStats.php
+++ b/lib/Model/GetContactCampaignStats.php
@@ -216,7 +216,7 @@ class GetContactCampaignStats implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['messagesSent'] = isset($data['messagesSent']) ? $data['messagesSent'] : null;
         $this->container['hardBounces'] = isset($data['hardBounces']) ? $data['hardBounces'] : null;

--- a/lib/Model/GetContactCampaignStatsClicked.php
+++ b/lib/Model/GetContactCampaignStatsClicked.php
@@ -180,7 +180,7 @@ class GetContactCampaignStatsClicked implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['campaignId'] = isset($data['campaignId']) ? $data['campaignId'] : null;
         $this->container['links'] = isset($data['links']) ? $data['links'] : null;

--- a/lib/Model/GetContactCampaignStatsOpened.php
+++ b/lib/Model/GetContactCampaignStatsOpened.php
@@ -190,7 +190,7 @@ class GetContactCampaignStatsOpened implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['campaignId'] = isset($data['campaignId']) ? $data['campaignId'] : null;
         $this->container['count'] = isset($data['count']) ? $data['count'] : null;

--- a/lib/Model/GetContactCampaignStatsTransacAttributes.php
+++ b/lib/Model/GetContactCampaignStatsTransacAttributes.php
@@ -185,7 +185,7 @@ class GetContactCampaignStatsTransacAttributes implements ModelInterface, ArrayA
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['orderDate'] = isset($data['orderDate']) ? $data['orderDate'] : null;
         $this->container['orderPrice'] = isset($data['orderPrice']) ? $data['orderPrice'] : null;

--- a/lib/Model/GetContactCampaignStatsUnsubscriptions.php
+++ b/lib/Model/GetContactCampaignStatsUnsubscriptions.php
@@ -180,7 +180,7 @@ class GetContactCampaignStatsUnsubscriptions implements ModelInterface, ArrayAcc
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['userUnsubscription'] = isset($data['userUnsubscription']) ? $data['userUnsubscription'] : null;
         $this->container['adminUnsubscription'] = isset($data['adminUnsubscription']) ? $data['adminUnsubscription'] : null;

--- a/lib/Model/GetContactDetails.php
+++ b/lib/Model/GetContactDetails.php
@@ -212,7 +212,7 @@ class GetContactDetails implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['email'] = isset($data['email']) ? $data['email'] : null;
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;

--- a/lib/Model/GetContacts.php
+++ b/lib/Model/GetContacts.php
@@ -177,7 +177,7 @@ class GetContacts implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['contacts'] = isset($data['contacts']) ? $data['contacts'] : null;
         $this->container['count'] = isset($data['count']) ? $data['count'] : null;

--- a/lib/Model/GetCorporateInvitedUsersList.php
+++ b/lib/Model/GetCorporateInvitedUsersList.php
@@ -175,7 +175,7 @@ class GetCorporateInvitedUsersList implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['users'] = isset($data['users']) ? $data['users'] : null;
     }

--- a/lib/Model/GetCorporateInvitedUsersListFeatureAccess.php
+++ b/lib/Model/GetCorporateInvitedUsersListFeatureAccess.php
@@ -191,7 +191,7 @@ class GetCorporateInvitedUsersListFeatureAccess implements ModelInterface, Array
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['userManagement'] = isset($data['userManagement']) ? $data['userManagement'] : null;
         $this->container['apiKeys'] = isset($data['apiKeys']) ? $data['apiKeys'] : null;

--- a/lib/Model/GetCorporateInvitedUsersListGroups.php
+++ b/lib/Model/GetCorporateInvitedUsersListGroups.php
@@ -181,7 +181,7 @@ class GetCorporateInvitedUsersListGroups implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;

--- a/lib/Model/GetCorporateInvitedUsersListUsers.php
+++ b/lib/Model/GetCorporateInvitedUsersListUsers.php
@@ -195,7 +195,7 @@ class GetCorporateInvitedUsersListUsers implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['groups'] = isset($data['groups']) ? $data['groups'] : null;
         $this->container['email'] = isset($data['email']) ? $data['email'] : null;

--- a/lib/Model/GetCouponCollection.php
+++ b/lib/Model/GetCouponCollection.php
@@ -200,7 +200,7 @@ class GetCouponCollection implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;

--- a/lib/Model/GetDeviceBrowserStats.php
+++ b/lib/Model/GetDeviceBrowserStats.php
@@ -190,7 +190,7 @@ class GetDeviceBrowserStats implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['clickers'] = isset($data['clickers']) ? $data['clickers'] : null;
         $this->container['uniqueClicks'] = isset($data['uniqueClicks']) ? $data['uniqueClicks'] : null;

--- a/lib/Model/GetDomainConfigurationModel.php
+++ b/lib/Model/GetDomainConfigurationModel.php
@@ -190,7 +190,7 @@ class GetDomainConfigurationModel implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['domain'] = isset($data['domain']) ? $data['domain'] : null;
         $this->container['verified'] = isset($data['verified']) ? $data['verified'] : null;

--- a/lib/Model/GetDomainsList.php
+++ b/lib/Model/GetDomainsList.php
@@ -175,7 +175,7 @@ class GetDomainsList implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['domains'] = isset($data['domains']) ? $data['domains'] : null;
     }

--- a/lib/Model/GetDomainsListDomains.php
+++ b/lib/Model/GetDomainsListDomains.php
@@ -195,7 +195,7 @@ class GetDomainsListDomains implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['domainName'] = isset($data['domainName']) ? $data['domainName'] : null;

--- a/lib/Model/GetEmailCampaign.php
+++ b/lib/Model/GetEmailCampaign.php
@@ -169,7 +169,7 @@ class GetEmailCampaign extends GetExtendedCampaignOverview
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         parent::__construct($data);
 

--- a/lib/Model/GetEmailEventReport.php
+++ b/lib/Model/GetEmailEventReport.php
@@ -175,7 +175,7 @@ class GetEmailEventReport implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['events'] = isset($data['events']) ? $data['events'] : null;
     }

--- a/lib/Model/GetEmailEventReportEvents.php
+++ b/lib/Model/GetEmailEventReportEvents.php
@@ -264,7 +264,7 @@ class GetEmailEventReportEvents implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['email'] = isset($data['email']) ? $data['email'] : null;
         $this->container['date'] = isset($data['date']) ? $data['date'] : null;

--- a/lib/Model/GetExtendedCampaignOverview.php
+++ b/lib/Model/GetExtendedCampaignOverview.php
@@ -354,7 +354,7 @@ class GetExtendedCampaignOverview implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;

--- a/lib/Model/GetExtendedCampaignOverviewSender.php
+++ b/lib/Model/GetExtendedCampaignOverviewSender.php
@@ -185,7 +185,7 @@ class GetExtendedCampaignOverviewSender implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
         $this->container['email'] = isset($data['email']) ? $data['email'] : null;

--- a/lib/Model/GetExtendedCampaignStats.php
+++ b/lib/Model/GetExtendedCampaignStats.php
@@ -210,7 +210,7 @@ class GetExtendedCampaignStats implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['globalStats'] = isset($data['globalStats']) ? $data['globalStats'] : null;
         $this->container['campaignStats'] = isset($data['campaignStats']) ? $data['campaignStats'] : null;

--- a/lib/Model/GetExtendedCampaignStatsGlobalStats.php
+++ b/lib/Model/GetExtendedCampaignStatsGlobalStats.php
@@ -176,7 +176,7 @@ class GetExtendedCampaignStatsGlobalStats implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
     }
 

--- a/lib/Model/GetExtendedClient.php
+++ b/lib/Model/GetExtendedClient.php
@@ -167,7 +167,7 @@ class GetExtendedClient extends GetClient
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         parent::__construct($data);
 

--- a/lib/Model/GetExtendedClientAddress.php
+++ b/lib/Model/GetExtendedClientAddress.php
@@ -191,7 +191,7 @@ class GetExtendedClientAddress implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['street'] = isset($data['street']) ? $data['street'] : null;
         $this->container['city'] = isset($data['city']) ? $data['city'] : null;

--- a/lib/Model/GetExtendedContactDetails.php
+++ b/lib/Model/GetExtendedContactDetails.php
@@ -221,7 +221,7 @@ class GetExtendedContactDetails implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['email'] = isset($data['email']) ? $data['email'] : null;
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;

--- a/lib/Model/GetExtendedContactDetailsStatistics.php
+++ b/lib/Model/GetExtendedContactDetailsStatistics.php
@@ -216,7 +216,7 @@ class GetExtendedContactDetailsStatistics implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['messagesSent'] = isset($data['messagesSent']) ? $data['messagesSent'] : null;
         $this->container['hardBounces'] = isset($data['hardBounces']) ? $data['hardBounces'] : null;

--- a/lib/Model/GetExtendedContactDetailsStatisticsClicked.php
+++ b/lib/Model/GetExtendedContactDetailsStatisticsClicked.php
@@ -180,7 +180,7 @@ class GetExtendedContactDetailsStatisticsClicked implements ModelInterface, Arra
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['campaignId'] = isset($data['campaignId']) ? $data['campaignId'] : null;
         $this->container['links'] = isset($data['links']) ? $data['links'] : null;

--- a/lib/Model/GetExtendedContactDetailsStatisticsDelivered.php
+++ b/lib/Model/GetExtendedContactDetailsStatisticsDelivered.php
@@ -180,7 +180,7 @@ class GetExtendedContactDetailsStatisticsDelivered implements ModelInterface, Ar
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['campaignId'] = isset($data['campaignId']) ? $data['campaignId'] : null;
         $this->container['eventTime'] = isset($data['eventTime']) ? $data['eventTime'] : null;

--- a/lib/Model/GetExtendedContactDetailsStatisticsLinks.php
+++ b/lib/Model/GetExtendedContactDetailsStatisticsLinks.php
@@ -190,7 +190,7 @@ class GetExtendedContactDetailsStatisticsLinks implements ModelInterface, ArrayA
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['count'] = isset($data['count']) ? $data['count'] : null;
         $this->container['eventTime'] = isset($data['eventTime']) ? $data['eventTime'] : null;

--- a/lib/Model/GetExtendedContactDetailsStatisticsMessagesSent.php
+++ b/lib/Model/GetExtendedContactDetailsStatisticsMessagesSent.php
@@ -180,7 +180,7 @@ class GetExtendedContactDetailsStatisticsMessagesSent implements ModelInterface,
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['campaignId'] = isset($data['campaignId']) ? $data['campaignId'] : null;
         $this->container['eventTime'] = isset($data['eventTime']) ? $data['eventTime'] : null;

--- a/lib/Model/GetExtendedContactDetailsStatisticsOpened.php
+++ b/lib/Model/GetExtendedContactDetailsStatisticsOpened.php
@@ -190,7 +190,7 @@ class GetExtendedContactDetailsStatisticsOpened implements ModelInterface, Array
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['campaignId'] = isset($data['campaignId']) ? $data['campaignId'] : null;
         $this->container['count'] = isset($data['count']) ? $data['count'] : null;

--- a/lib/Model/GetExtendedContactDetailsStatisticsUnsubscriptions.php
+++ b/lib/Model/GetExtendedContactDetailsStatisticsUnsubscriptions.php
@@ -181,7 +181,7 @@ class GetExtendedContactDetailsStatisticsUnsubscriptions implements ModelInterfa
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['userUnsubscription'] = isset($data['userUnsubscription']) ? $data['userUnsubscription'] : null;
         $this->container['adminUnsubscription'] = isset($data['adminUnsubscription']) ? $data['adminUnsubscription'] : null;

--- a/lib/Model/GetExtendedContactDetailsStatisticsUnsubscriptionsAdminUnsubscription.php
+++ b/lib/Model/GetExtendedContactDetailsStatisticsUnsubscriptionsAdminUnsubscription.php
@@ -180,7 +180,7 @@ class GetExtendedContactDetailsStatisticsUnsubscriptionsAdminUnsubscription impl
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['eventTime'] = isset($data['eventTime']) ? $data['eventTime'] : null;
         $this->container['ip'] = isset($data['ip']) ? $data['ip'] : null;

--- a/lib/Model/GetExtendedContactDetailsStatisticsUnsubscriptionsUserUnsubscription.php
+++ b/lib/Model/GetExtendedContactDetailsStatisticsUnsubscriptionsUserUnsubscription.php
@@ -185,7 +185,7 @@ class GetExtendedContactDetailsStatisticsUnsubscriptionsUserUnsubscription imple
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['campaignId'] = isset($data['campaignId']) ? $data['campaignId'] : null;
         $this->container['eventTime'] = isset($data['eventTime']) ? $data['eventTime'] : null;

--- a/lib/Model/GetExtendedList.php
+++ b/lib/Model/GetExtendedList.php
@@ -182,7 +182,7 @@ class GetExtendedList extends GetList
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         parent::__construct($data);
 

--- a/lib/Model/GetExtendedListCampaignStats.php
+++ b/lib/Model/GetExtendedListCampaignStats.php
@@ -180,7 +180,7 @@ class GetExtendedListCampaignStats implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['campaignId'] = isset($data['campaignId']) ? $data['campaignId'] : null;
         $this->container['stats'] = isset($data['stats']) ? $data['stats'] : null;

--- a/lib/Model/GetExternalFeedByUUID.php
+++ b/lib/Model/GetExternalFeedByUUID.php
@@ -247,7 +247,7 @@ class GetExternalFeedByUUID implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;

--- a/lib/Model/GetExternalFeedByUUIDHeaders.php
+++ b/lib/Model/GetExternalFeedByUUIDHeaders.php
@@ -180,7 +180,7 @@ class GetExternalFeedByUUIDHeaders implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
         $this->container['value'] = isset($data['value']) ? $data['value'] : null;

--- a/lib/Model/GetFolder.php
+++ b/lib/Model/GetFolder.php
@@ -195,7 +195,7 @@ class GetFolder implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;

--- a/lib/Model/GetFolderLists.php
+++ b/lib/Model/GetFolderLists.php
@@ -180,7 +180,7 @@ class GetFolderLists implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['lists'] = isset($data['lists']) ? $data['lists'] : null;
         $this->container['count'] = isset($data['count']) ? $data['count'] : null;

--- a/lib/Model/GetFolders.php
+++ b/lib/Model/GetFolders.php
@@ -180,7 +180,7 @@ class GetFolders implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['folders'] = isset($data['folders']) ? $data['folders'] : null;
         $this->container['count'] = isset($data['count']) ? $data['count'] : null;

--- a/lib/Model/GetInboundEmailEvents.php
+++ b/lib/Model/GetInboundEmailEvents.php
@@ -175,7 +175,7 @@ class GetInboundEmailEvents implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['events'] = isset($data['events']) ? $data['events'] : null;
     }

--- a/lib/Model/GetInboundEmailEventsByUuid.php
+++ b/lib/Model/GetInboundEmailEventsByUuid.php
@@ -210,7 +210,7 @@ class GetInboundEmailEventsByUuid implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['receivedAt'] = isset($data['receivedAt']) ? $data['receivedAt'] : null;
         $this->container['deliveredAt'] = isset($data['deliveredAt']) ? $data['deliveredAt'] : null;

--- a/lib/Model/GetInboundEmailEventsByUuidAttachments.php
+++ b/lib/Model/GetInboundEmailEventsByUuidAttachments.php
@@ -190,7 +190,7 @@ class GetInboundEmailEventsByUuidAttachments implements ModelInterface, ArrayAcc
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
         $this->container['contentType'] = isset($data['contentType']) ? $data['contentType'] : null;

--- a/lib/Model/GetInboundEmailEventsByUuidLogs.php
+++ b/lib/Model/GetInboundEmailEventsByUuidLogs.php
@@ -199,7 +199,7 @@ class GetInboundEmailEventsByUuidLogs implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['date'] = isset($data['date']) ? $data['date'] : null;
         $this->container['type'] = isset($data['type']) ? $data['type'] : null;

--- a/lib/Model/GetInboundEmailEventsEvents.php
+++ b/lib/Model/GetInboundEmailEventsEvents.php
@@ -190,7 +190,7 @@ class GetInboundEmailEventsEvents implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['uuid'] = isset($data['uuid']) ? $data['uuid'] : null;
         $this->container['date'] = isset($data['date']) ? $data['date'] : null;

--- a/lib/Model/GetInvitedUsersList.php
+++ b/lib/Model/GetInvitedUsersList.php
@@ -175,7 +175,7 @@ class GetInvitedUsersList implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['users'] = isset($data['users']) ? $data['users'] : null;
     }

--- a/lib/Model/GetInvitedUsersListFeatureAccess.php
+++ b/lib/Model/GetInvitedUsersListFeatureAccess.php
@@ -186,7 +186,7 @@ class GetInvitedUsersListFeatureAccess implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['marketing'] = isset($data['marketing']) ? $data['marketing'] : null;
         $this->container['conversations'] = isset($data['conversations']) ? $data['conversations'] : null;

--- a/lib/Model/GetInvitedUsersListUsers.php
+++ b/lib/Model/GetInvitedUsersListUsers.php
@@ -190,7 +190,7 @@ class GetInvitedUsersListUsers implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['email'] = isset($data['email']) ? $data['email'] : null;
         $this->container['isOwner'] = isset($data['isOwner']) ? $data['isOwner'] : null;

--- a/lib/Model/GetIp.php
+++ b/lib/Model/GetIp.php
@@ -190,7 +190,7 @@ class GetIp implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['ip'] = isset($data['ip']) ? $data['ip'] : null;

--- a/lib/Model/GetIpFromSender.php
+++ b/lib/Model/GetIpFromSender.php
@@ -190,7 +190,7 @@ class GetIpFromSender implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['ip'] = isset($data['ip']) ? $data['ip'] : null;

--- a/lib/Model/GetIps.php
+++ b/lib/Model/GetIps.php
@@ -175,7 +175,7 @@ class GetIps implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['ips'] = isset($data['ips']) ? $data['ips'] : null;
     }

--- a/lib/Model/GetIpsFromSender.php
+++ b/lib/Model/GetIpsFromSender.php
@@ -175,7 +175,7 @@ class GetIpsFromSender implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['ips'] = isset($data['ips']) ? $data['ips'] : null;
     }

--- a/lib/Model/GetList.php
+++ b/lib/Model/GetList.php
@@ -195,7 +195,7 @@ class GetList implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;

--- a/lib/Model/GetLists.php
+++ b/lib/Model/GetLists.php
@@ -180,7 +180,7 @@ class GetLists implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['lists'] = isset($data['lists']) ? $data['lists'] : null;
         $this->container['count'] = isset($data['count']) ? $data['count'] : null;

--- a/lib/Model/GetOrders.php
+++ b/lib/Model/GetOrders.php
@@ -180,7 +180,7 @@ class GetOrders implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['orders'] = isset($data['orders']) ? $data['orders'] : null;
         $this->container['count'] = isset($data['count']) ? $data['count'] : null;

--- a/lib/Model/GetProcess.php
+++ b/lib/Model/GetProcess.php
@@ -207,7 +207,7 @@ class GetProcess implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['status'] = isset($data['status']) ? $data['status'] : null;

--- a/lib/Model/GetProcesses.php
+++ b/lib/Model/GetProcesses.php
@@ -180,7 +180,7 @@ class GetProcesses implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['processes'] = isset($data['processes']) ? $data['processes'] : null;
         $this->container['count'] = isset($data['count']) ? $data['count'] : null;

--- a/lib/Model/GetProductDetails.php
+++ b/lib/Model/GetProductDetails.php
@@ -245,7 +245,7 @@ class GetProductDetails implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;

--- a/lib/Model/GetProducts.php
+++ b/lib/Model/GetProducts.php
@@ -180,7 +180,7 @@ class GetProducts implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['products'] = isset($data['products']) ? $data['products'] : null;
         $this->container['count'] = isset($data['count']) ? $data['count'] : null;

--- a/lib/Model/GetReports.php
+++ b/lib/Model/GetReports.php
@@ -175,7 +175,7 @@ class GetReports implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['reports'] = isset($data['reports']) ? $data['reports'] : null;
     }

--- a/lib/Model/GetReportsReports.php
+++ b/lib/Model/GetReportsReports.php
@@ -235,7 +235,7 @@ class GetReportsReports implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['date'] = isset($data['date']) ? $data['date'] : null;
         $this->container['requests'] = isset($data['requests']) ? $data['requests'] : null;

--- a/lib/Model/GetScheduledEmailByBatchId.php
+++ b/lib/Model/GetScheduledEmailByBatchId.php
@@ -180,7 +180,7 @@ class GetScheduledEmailByBatchId implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['count'] = isset($data['count']) ? $data['count'] : null;
         $this->container['batches'] = isset($data['batches']) ? $data['batches'] : null;

--- a/lib/Model/GetScheduledEmailByBatchIdBatches.php
+++ b/lib/Model/GetScheduledEmailByBatchIdBatches.php
@@ -204,7 +204,7 @@ class GetScheduledEmailByBatchIdBatches implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['scheduledAt'] = isset($data['scheduledAt']) ? $data['scheduledAt'] : null;
         $this->container['createdAt'] = isset($data['createdAt']) ? $data['createdAt'] : null;

--- a/lib/Model/GetScheduledEmailByMessageId.php
+++ b/lib/Model/GetScheduledEmailByMessageId.php
@@ -204,7 +204,7 @@ class GetScheduledEmailByMessageId implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['scheduledAt'] = isset($data['scheduledAt']) ? $data['scheduledAt'] : null;
         $this->container['createdAt'] = isset($data['createdAt']) ? $data['createdAt'] : null;

--- a/lib/Model/GetSegments.php
+++ b/lib/Model/GetSegments.php
@@ -180,7 +180,7 @@ class GetSegments implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['segments'] = isset($data['segments']) ? $data['segments'] : null;
         $this->container['count'] = isset($data['count']) ? $data['count'] : null;

--- a/lib/Model/GetSegmentsSegments.php
+++ b/lib/Model/GetSegmentsSegments.php
@@ -190,7 +190,7 @@ class GetSegmentsSegments implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['segmentName'] = isset($data['segmentName']) ? $data['segmentName'] : null;

--- a/lib/Model/GetSendersList.php
+++ b/lib/Model/GetSendersList.php
@@ -175,7 +175,7 @@ class GetSendersList implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['senders'] = isset($data['senders']) ? $data['senders'] : null;
     }

--- a/lib/Model/GetSendersListIps.php
+++ b/lib/Model/GetSendersListIps.php
@@ -185,7 +185,7 @@ class GetSendersListIps implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['ip'] = isset($data['ip']) ? $data['ip'] : null;
         $this->container['domain'] = isset($data['domain']) ? $data['domain'] : null;

--- a/lib/Model/GetSendersListSenders.php
+++ b/lib/Model/GetSendersListSenders.php
@@ -195,7 +195,7 @@ class GetSendersListSenders implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;

--- a/lib/Model/GetSharedTemplateUrl.php
+++ b/lib/Model/GetSharedTemplateUrl.php
@@ -175,7 +175,7 @@ class GetSharedTemplateUrl implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['sharedUrl'] = isset($data['sharedUrl']) ? $data['sharedUrl'] : null;
     }

--- a/lib/Model/GetSmsCampaign.php
+++ b/lib/Model/GetSmsCampaign.php
@@ -243,7 +243,7 @@ class GetSmsCampaign implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;

--- a/lib/Model/GetSmsCampaignOverview.php
+++ b/lib/Model/GetSmsCampaignOverview.php
@@ -233,7 +233,7 @@ class GetSmsCampaignOverview implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;

--- a/lib/Model/GetSmsCampaignRecipients.php
+++ b/lib/Model/GetSmsCampaignRecipients.php
@@ -175,7 +175,7 @@ class GetSmsCampaignRecipients implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
     }
 

--- a/lib/Model/GetSmsCampaignStats.php
+++ b/lib/Model/GetSmsCampaignStats.php
@@ -205,7 +205,7 @@ class GetSmsCampaignStats implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['delivered'] = isset($data['delivered']) ? $data['delivered'] : null;
         $this->container['sent'] = isset($data['sent']) ? $data['sent'] : null;

--- a/lib/Model/GetSmsCampaigns.php
+++ b/lib/Model/GetSmsCampaigns.php
@@ -180,7 +180,7 @@ class GetSmsCampaigns implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['campaigns'] = isset($data['campaigns']) ? $data['campaigns'] : null;
         $this->container['count'] = isset($data['count']) ? $data['count'] : null;

--- a/lib/Model/GetSmsEventReport.php
+++ b/lib/Model/GetSmsEventReport.php
@@ -175,7 +175,7 @@ class GetSmsEventReport implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['events'] = isset($data['events']) ? $data['events'] : null;
     }

--- a/lib/Model/GetSmsEventReportEvents.php
+++ b/lib/Model/GetSmsEventReportEvents.php
@@ -236,7 +236,7 @@ class GetSmsEventReportEvents implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['phoneNumber'] = isset($data['phoneNumber']) ? $data['phoneNumber'] : null;
         $this->container['date'] = isset($data['date']) ? $data['date'] : null;

--- a/lib/Model/GetSmtpTemplateOverview.php
+++ b/lib/Model/GetSmtpTemplateOverview.php
@@ -235,7 +235,7 @@ class GetSmtpTemplateOverview implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;

--- a/lib/Model/GetSmtpTemplateOverviewSender.php
+++ b/lib/Model/GetSmtpTemplateOverviewSender.php
@@ -185,7 +185,7 @@ class GetSmtpTemplateOverviewSender implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
         $this->container['email'] = isset($data['email']) ? $data['email'] : null;

--- a/lib/Model/GetSmtpTemplates.php
+++ b/lib/Model/GetSmtpTemplates.php
@@ -180,7 +180,7 @@ class GetSmtpTemplates implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['count'] = isset($data['count']) ? $data['count'] : null;
         $this->container['templates'] = isset($data['templates']) ? $data['templates'] : null;

--- a/lib/Model/GetSsoToken.php
+++ b/lib/Model/GetSsoToken.php
@@ -175,7 +175,7 @@ class GetSsoToken implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['token'] = isset($data['token']) ? $data['token'] : null;
     }

--- a/lib/Model/GetStatsByBrowser.php
+++ b/lib/Model/GetStatsByBrowser.php
@@ -175,7 +175,7 @@ class GetStatsByBrowser implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
     }
 

--- a/lib/Model/GetStatsByDevice.php
+++ b/lib/Model/GetStatsByDevice.php
@@ -190,7 +190,7 @@ class GetStatsByDevice implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['desktop'] = isset($data['desktop']) ? $data['desktop'] : null;
         $this->container['mobile'] = isset($data['mobile']) ? $data['mobile'] : null;

--- a/lib/Model/GetStatsByDomain.php
+++ b/lib/Model/GetStatsByDomain.php
@@ -175,7 +175,7 @@ class GetStatsByDomain implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
     }
 

--- a/lib/Model/GetTransacAggregatedSmsReport.php
+++ b/lib/Model/GetTransacAggregatedSmsReport.php
@@ -220,7 +220,7 @@ class GetTransacAggregatedSmsReport implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['range'] = isset($data['range']) ? $data['range'] : null;
         $this->container['requests'] = isset($data['requests']) ? $data['requests'] : null;

--- a/lib/Model/GetTransacBlockedContacts.php
+++ b/lib/Model/GetTransacBlockedContacts.php
@@ -180,7 +180,7 @@ class GetTransacBlockedContacts implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['count'] = isset($data['count']) ? $data['count'] : null;
         $this->container['contacts'] = isset($data['contacts']) ? $data['contacts'] : null;

--- a/lib/Model/GetTransacBlockedContactsContacts.php
+++ b/lib/Model/GetTransacBlockedContactsContacts.php
@@ -190,7 +190,7 @@ class GetTransacBlockedContactsContacts implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['email'] = isset($data['email']) ? $data['email'] : null;
         $this->container['senderEmail'] = isset($data['senderEmail']) ? $data['senderEmail'] : null;

--- a/lib/Model/GetTransacBlockedContactsReason.php
+++ b/lib/Model/GetTransacBlockedContactsReason.php
@@ -204,7 +204,7 @@ class GetTransacBlockedContactsReason implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['code'] = isset($data['code']) ? $data['code'] : null;
         $this->container['message'] = isset($data['message']) ? $data['message'] : null;

--- a/lib/Model/GetTransacEmailContent.php
+++ b/lib/Model/GetTransacEmailContent.php
@@ -205,7 +205,7 @@ class GetTransacEmailContent implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['email'] = isset($data['email']) ? $data['email'] : null;
         $this->container['subject'] = isset($data['subject']) ? $data['subject'] : null;

--- a/lib/Model/GetTransacEmailContentEvents.php
+++ b/lib/Model/GetTransacEmailContentEvents.php
@@ -180,7 +180,7 @@ class GetTransacEmailContentEvents implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
         $this->container['time'] = isset($data['time']) ? $data['time'] : null;

--- a/lib/Model/GetTransacSmsReport.php
+++ b/lib/Model/GetTransacSmsReport.php
@@ -175,7 +175,7 @@ class GetTransacSmsReport implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['reports'] = isset($data['reports']) ? $data['reports'] : null;
     }

--- a/lib/Model/GetTransacSmsReportReports.php
+++ b/lib/Model/GetTransacSmsReportReports.php
@@ -220,7 +220,7 @@ class GetTransacSmsReportReports implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['date'] = isset($data['date']) ? $data['date'] : null;
         $this->container['requests'] = isset($data['requests']) ? $data['requests'] : null;

--- a/lib/Model/GetUserPermission.php
+++ b/lib/Model/GetUserPermission.php
@@ -186,7 +186,7 @@ class GetUserPermission implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['email'] = isset($data['email']) ? $data['email'] : null;
         $this->container['status'] = isset($data['status']) ? $data['status'] : null;

--- a/lib/Model/GetUserPermissionPrivileges.php
+++ b/lib/Model/GetUserPermissionPrivileges.php
@@ -180,7 +180,7 @@ class GetUserPermissionPrivileges implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['feature'] = isset($data['feature']) ? $data['feature'] : null;
         $this->container['permissions'] = isset($data['permissions']) ? $data['permissions'] : null;

--- a/lib/Model/GetWATemplates.php
+++ b/lib/Model/GetWATemplates.php
@@ -180,7 +180,7 @@ class GetWATemplates implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['templates'] = isset($data['templates']) ? $data['templates'] : null;
         $this->container['count'] = isset($data['count']) ? $data['count'] : null;

--- a/lib/Model/GetWATemplatesTemplates.php
+++ b/lib/Model/GetWATemplatesTemplates.php
@@ -210,7 +210,7 @@ class GetWATemplatesTemplates implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;

--- a/lib/Model/GetWebhook.php
+++ b/lib/Model/GetWebhook.php
@@ -235,7 +235,7 @@ class GetWebhook implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['url'] = isset($data['url']) ? $data['url'] : null;
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;

--- a/lib/Model/GetWebhookAuth.php
+++ b/lib/Model/GetWebhookAuth.php
@@ -181,7 +181,7 @@ class GetWebhookAuth implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['type'] = isset($data['type']) ? $data['type'] : null;
         $this->container['token'] = isset($data['token']) ? $data['token'] : null;

--- a/lib/Model/GetWebhookHeaders.php
+++ b/lib/Model/GetWebhookHeaders.php
@@ -180,7 +180,7 @@ class GetWebhookHeaders implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['key'] = isset($data['key']) ? $data['key'] : null;
         $this->container['value'] = isset($data['value']) ? $data['value'] : null;

--- a/lib/Model/GetWebhooks.php
+++ b/lib/Model/GetWebhooks.php
@@ -175,7 +175,7 @@ class GetWebhooks implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['webhooks'] = isset($data['webhooks']) ? $data['webhooks'] : null;
     }

--- a/lib/Model/GetWhatsAppConfig.php
+++ b/lib/Model/GetWhatsAppConfig.php
@@ -234,7 +234,7 @@ class GetWhatsAppConfig implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['whatsappBusinessAccountId'] = isset($data['whatsappBusinessAccountId']) ? $data['whatsappBusinessAccountId'] : null;
         $this->container['sendingLimit'] = isset($data['sendingLimit']) ? $data['sendingLimit'] : null;

--- a/lib/Model/GetWhatsappCampaignOverview.php
+++ b/lib/Model/GetWhatsappCampaignOverview.php
@@ -242,7 +242,7 @@ class GetWhatsappCampaignOverview implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['campaignName'] = isset($data['campaignName']) ? $data['campaignName'] : null;

--- a/lib/Model/GetWhatsappCampaigns.php
+++ b/lib/Model/GetWhatsappCampaigns.php
@@ -180,7 +180,7 @@ class GetWhatsappCampaigns implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['campaigns'] = isset($data['campaigns']) ? $data['campaigns'] : null;
         $this->container['count'] = isset($data['count']) ? $data['count'] : null;

--- a/lib/Model/GetWhatsappCampaignsCampaigns.php
+++ b/lib/Model/GetWhatsappCampaignsCampaigns.php
@@ -252,7 +252,7 @@ class GetWhatsappCampaignsCampaigns implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['campaignName'] = isset($data['campaignName']) ? $data['campaignName'] : null;

--- a/lib/Model/GetWhatsappEventReport.php
+++ b/lib/Model/GetWhatsappEventReport.php
@@ -175,7 +175,7 @@ class GetWhatsappEventReport implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['events'] = isset($data['events']) ? $data['events'] : null;
     }

--- a/lib/Model/GetWhatsappEventReportEvents.php
+++ b/lib/Model/GetWhatsappEventReportEvents.php
@@ -235,7 +235,7 @@ class GetWhatsappEventReportEvents implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['contactNumber'] = isset($data['contactNumber']) ? $data['contactNumber'] : null;
         $this->container['date'] = isset($data['date']) ? $data['date'] : null;

--- a/lib/Model/InlineResponse200.php
+++ b/lib/Model/InlineResponse200.php
@@ -180,7 +180,7 @@ class InlineResponse200 implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['groupName'] = isset($data['groupName']) ? $data['groupName'] : null;

--- a/lib/Model/InlineResponse2001.php
+++ b/lib/Model/InlineResponse2001.php
@@ -176,7 +176,7 @@ class InlineResponse2001 implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
     }

--- a/lib/Model/InlineResponse2002.php
+++ b/lib/Model/InlineResponse2002.php
@@ -185,7 +185,7 @@ class InlineResponse2002 implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;

--- a/lib/Model/InlineResponse201.php
+++ b/lib/Model/InlineResponse201.php
@@ -175,7 +175,7 @@ class InlineResponse201 implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
     }

--- a/lib/Model/InlineResponse2011.php
+++ b/lib/Model/InlineResponse2011.php
@@ -176,7 +176,7 @@ class InlineResponse2011 implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
     }

--- a/lib/Model/InlineResponse2012.php
+++ b/lib/Model/InlineResponse2012.php
@@ -176,7 +176,7 @@ class InlineResponse2012 implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
     }

--- a/lib/Model/InlineResponse2013.php
+++ b/lib/Model/InlineResponse2013.php
@@ -175,7 +175,7 @@ class InlineResponse2013 implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
     }

--- a/lib/Model/InlineResponse2014.php
+++ b/lib/Model/InlineResponse2014.php
@@ -175,7 +175,7 @@ class InlineResponse2014 implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['messageId'] = isset($data['messageId']) ? $data['messageId'] : null;
     }

--- a/lib/Model/InlineResponse2015.php
+++ b/lib/Model/InlineResponse2015.php
@@ -175,7 +175,7 @@ class InlineResponse2015 implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
     }

--- a/lib/Model/InviteAdminUser.php
+++ b/lib/Model/InviteAdminUser.php
@@ -190,7 +190,7 @@ class InviteAdminUser implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['email'] = isset($data['email']) ? $data['email'] : null;
         $this->container['allFeaturesAccess'] = isset($data['allFeaturesAccess']) ? $data['allFeaturesAccess'] : null;

--- a/lib/Model/InviteAdminUserPrivileges.php
+++ b/lib/Model/InviteAdminUserPrivileges.php
@@ -215,7 +215,7 @@ class InviteAdminUserPrivileges implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['feature'] = isset($data['feature']) ? $data['feature'] : null;
         $this->container['permissions'] = isset($data['permissions']) ? $data['permissions'] : null;

--- a/lib/Model/Inviteuser.php
+++ b/lib/Model/Inviteuser.php
@@ -185,7 +185,7 @@ class Inviteuser implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['email'] = isset($data['email']) ? $data['email'] : null;
         $this->container['allFeaturesAccess'] = isset($data['allFeaturesAccess']) ? $data['allFeaturesAccess'] : null;

--- a/lib/Model/InviteuserPrivileges.php
+++ b/lib/Model/InviteuserPrivileges.php
@@ -287,7 +287,7 @@ class InviteuserPrivileges implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['feature'] = isset($data['feature']) ? $data['feature'] : null;
         $this->container['permissions'] = isset($data['permissions']) ? $data['permissions'] : null;

--- a/lib/Model/ManageIp.php
+++ b/lib/Model/ManageIp.php
@@ -175,7 +175,7 @@ class ManageIp implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['ip'] = isset($data['ip']) ? $data['ip'] : null;
     }

--- a/lib/Model/MasterDetailsResponse.php
+++ b/lib/Model/MasterDetailsResponse.php
@@ -205,7 +205,7 @@ class MasterDetailsResponse implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['email'] = isset($data['email']) ? $data['email'] : null;
         $this->container['companyName'] = isset($data['companyName']) ? $data['companyName'] : null;

--- a/lib/Model/MasterDetailsResponseBillingInfo.php
+++ b/lib/Model/MasterDetailsResponseBillingInfo.php
@@ -191,7 +191,7 @@ class MasterDetailsResponseBillingInfo implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['email'] = isset($data['email']) ? $data['email'] : null;
         $this->container['companyName'] = isset($data['companyName']) ? $data['companyName'] : null;

--- a/lib/Model/MasterDetailsResponseBillingInfoAddress.php
+++ b/lib/Model/MasterDetailsResponseBillingInfoAddress.php
@@ -196,7 +196,7 @@ class MasterDetailsResponseBillingInfoAddress implements ModelInterface, ArrayAc
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['streetAddress'] = isset($data['streetAddress']) ? $data['streetAddress'] : null;
         $this->container['locality'] = isset($data['locality']) ? $data['locality'] : null;

--- a/lib/Model/MasterDetailsResponseBillingInfoName.php
+++ b/lib/Model/MasterDetailsResponseBillingInfoName.php
@@ -181,7 +181,7 @@ class MasterDetailsResponseBillingInfoName implements ModelInterface, ArrayAcces
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['givenName'] = isset($data['givenName']) ? $data['givenName'] : null;
         $this->container['familyName'] = isset($data['familyName']) ? $data['familyName'] : null;

--- a/lib/Model/MasterDetailsResponsePlanInfo.php
+++ b/lib/Model/MasterDetailsResponsePlanInfo.php
@@ -216,7 +216,7 @@ class MasterDetailsResponsePlanInfo implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['currencyCode'] = isset($data['currencyCode']) ? $data['currencyCode'] : null;
         $this->container['nextBillingAt'] = isset($data['nextBillingAt']) ? $data['nextBillingAt'] : null;

--- a/lib/Model/MasterDetailsResponsePlanInfoFeatures.php
+++ b/lib/Model/MasterDetailsResponsePlanInfoFeatures.php
@@ -205,7 +205,7 @@ class MasterDetailsResponsePlanInfoFeatures implements ModelInterface, ArrayAcce
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
         $this->container['unitValue'] = isset($data['unitValue']) ? $data['unitValue'] : null;

--- a/lib/Model/Note.php
+++ b/lib/Model/Note.php
@@ -206,7 +206,7 @@ class Note implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['text'] = isset($data['text']) ? $data['text'] : null;

--- a/lib/Model/NoteData.php
+++ b/lib/Model/NoteData.php
@@ -191,7 +191,7 @@ class NoteData implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['text'] = isset($data['text']) ? $data['text'] : null;
         $this->container['contactIds'] = isset($data['contactIds']) ? $data['contactIds'] : null;

--- a/lib/Model/NoteId.php
+++ b/lib/Model/NoteId.php
@@ -176,7 +176,7 @@ class NoteId implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
     }

--- a/lib/Model/NoteList.php
+++ b/lib/Model/NoteList.php
@@ -176,7 +176,7 @@ class NoteList implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
     }
 

--- a/lib/Model/Order.php
+++ b/lib/Model/Order.php
@@ -215,7 +215,7 @@ class Order implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['createdAt'] = isset($data['createdAt']) ? $data['createdAt'] : null;

--- a/lib/Model/OrderBatch.php
+++ b/lib/Model/OrderBatch.php
@@ -185,7 +185,7 @@ class OrderBatch implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['orders'] = isset($data['orders']) ? $data['orders'] : null;
         $this->container['notifyUrl'] = isset($data['notifyUrl']) ? $data['notifyUrl'] : null;

--- a/lib/Model/OrderBilling.php
+++ b/lib/Model/OrderBilling.php
@@ -206,7 +206,7 @@ class OrderBilling implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['address'] = isset($data['address']) ? $data['address'] : null;
         $this->container['city'] = isset($data['city']) ? $data['city'] : null;

--- a/lib/Model/OrderProducts.php
+++ b/lib/Model/OrderProducts.php
@@ -191,7 +191,7 @@ class OrderProducts implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['productId'] = isset($data['productId']) ? $data['productId'] : null;
         $this->container['quantity'] = isset($data['quantity']) ? $data['quantity'] : null;

--- a/lib/Model/Otp.php
+++ b/lib/Model/Otp.php
@@ -175,7 +175,7 @@ class Otp implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
     }

--- a/lib/Model/Pipeline.php
+++ b/lib/Model/Pipeline.php
@@ -186,7 +186,7 @@ class Pipeline implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['pipeline'] = isset($data['pipeline']) ? $data['pipeline'] : null;
         $this->container['pipelineName'] = isset($data['pipelineName']) ? $data['pipelineName'] : null;

--- a/lib/Model/PipelineStage.php
+++ b/lib/Model/PipelineStage.php
@@ -181,7 +181,7 @@ class PipelineStage implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;

--- a/lib/Model/Pipelines.php
+++ b/lib/Model/Pipelines.php
@@ -176,7 +176,7 @@ class Pipelines implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
     }
 

--- a/lib/Model/PostContactInfo.php
+++ b/lib/Model/PostContactInfo.php
@@ -175,7 +175,7 @@ class PostContactInfo implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['contacts'] = isset($data['contacts']) ? $data['contacts'] : null;
     }

--- a/lib/Model/PostContactInfoContacts.php
+++ b/lib/Model/PostContactInfoContacts.php
@@ -190,7 +190,7 @@ class PostContactInfoContacts implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['success'] = isset($data['success']) ? $data['success'] : null;
         $this->container['failure'] = isset($data['failure']) ? $data['failure'] : null;

--- a/lib/Model/PostSendFailed.php
+++ b/lib/Model/PostSendFailed.php
@@ -195,7 +195,7 @@ class PostSendFailed implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['code'] = isset($data['code']) ? $data['code'] : null;
         $this->container['message'] = isset($data['message']) ? $data['message'] : null;

--- a/lib/Model/PostSendSmsTestFailed.php
+++ b/lib/Model/PostSendSmsTestFailed.php
@@ -190,7 +190,7 @@ class PostSendSmsTestFailed implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['code'] = isset($data['code']) ? $data['code'] : null;
         $this->container['message'] = isset($data['message']) ? $data['message'] : null;

--- a/lib/Model/PutRevokeUserPermission.php
+++ b/lib/Model/PutRevokeUserPermission.php
@@ -176,7 +176,7 @@ class PutRevokeUserPermission implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['email'] = isset($data['email']) ? $data['email'] : null;
     }

--- a/lib/Model/Putresendcancelinvitation.php
+++ b/lib/Model/Putresendcancelinvitation.php
@@ -176,7 +176,7 @@ class Putresendcancelinvitation implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['email'] = isset($data['email']) ? $data['email'] : null;
     }

--- a/lib/Model/RemainingCreditModel.php
+++ b/lib/Model/RemainingCreditModel.php
@@ -180,7 +180,7 @@ class RemainingCreditModel implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['child'] = isset($data['child']) ? $data['child'] : null;
         $this->container['reseller'] = isset($data['reseller']) ? $data['reseller'] : null;

--- a/lib/Model/RemainingCreditModelChild.php
+++ b/lib/Model/RemainingCreditModelChild.php
@@ -181,7 +181,7 @@ class RemainingCreditModelChild implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['sms'] = isset($data['sms']) ? $data['sms'] : null;
         $this->container['email'] = isset($data['email']) ? $data['email'] : null;

--- a/lib/Model/RemainingCreditModelReseller.php
+++ b/lib/Model/RemainingCreditModelReseller.php
@@ -180,7 +180,7 @@ class RemainingCreditModelReseller implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['sms'] = isset($data['sms']) ? $data['sms'] : null;
         $this->container['email'] = isset($data['email']) ? $data['email'] : null;

--- a/lib/Model/RemoveContactFromList.php
+++ b/lib/Model/RemoveContactFromList.php
@@ -187,7 +187,7 @@ class RemoveContactFromList implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['emails'] = isset($data['emails']) ? $data['emails'] : null;
         $this->container['ids'] = isset($data['ids']) ? $data['ids'] : null;

--- a/lib/Model/RemoveCredits.php
+++ b/lib/Model/RemoveCredits.php
@@ -180,7 +180,7 @@ class RemoveCredits implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['sms'] = isset($data['sms']) ? $data['sms'] : null;
         $this->container['email'] = isset($data['email']) ? $data['email'] : null;

--- a/lib/Model/RequestContactExport.php
+++ b/lib/Model/RequestContactExport.php
@@ -202,7 +202,7 @@ class RequestContactExport implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['exportAttributes'] = isset($data['exportAttributes']) ? $data['exportAttributes'] : null;
         $this->container['customContactFilter'] = isset($data['customContactFilter']) ? $data['customContactFilter'] : null;

--- a/lib/Model/RequestContactExportCustomContactFilter.php
+++ b/lib/Model/RequestContactExportCustomContactFilter.php
@@ -262,7 +262,7 @@ class RequestContactExportCustomContactFilter implements ModelInterface, ArrayAc
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['actionForContacts'] = isset($data['actionForContacts']) ? $data['actionForContacts'] : null;
         $this->container['actionForEmailCampaigns'] = isset($data['actionForEmailCampaigns']) ? $data['actionForEmailCampaigns'] : null;

--- a/lib/Model/RequestContactImport.php
+++ b/lib/Model/RequestContactImport.php
@@ -222,7 +222,7 @@ class RequestContactImport implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['fileUrl'] = isset($data['fileUrl']) ? $data['fileUrl'] : null;
         $this->container['fileBody'] = isset($data['fileBody']) ? $data['fileBody'] : null;

--- a/lib/Model/RequestContactImportJsonBody.php
+++ b/lib/Model/RequestContactImportJsonBody.php
@@ -180,7 +180,7 @@ class RequestContactImportJsonBody implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['email'] = isset($data['email']) ? $data['email'] : null;
         $this->container['attributes'] = isset($data['attributes']) ? $data['attributes'] : null;

--- a/lib/Model/RequestContactImportNewList.php
+++ b/lib/Model/RequestContactImportNewList.php
@@ -181,7 +181,7 @@ class RequestContactImportNewList implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['listName'] = isset($data['listName']) ? $data['listName'] : null;
         $this->container['folderId'] = isset($data['folderId']) ? $data['folderId'] : null;

--- a/lib/Model/RequestSmsRecipientExport.php
+++ b/lib/Model/RequestSmsRecipientExport.php
@@ -203,7 +203,7 @@ class RequestSmsRecipientExport implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['notifyURL'] = isset($data['notifyURL']) ? $data['notifyURL'] : null;
         $this->container['recipientsType'] = isset($data['recipientsType']) ? $data['recipientsType'] : null;

--- a/lib/Model/ScheduleSmtpEmail.php
+++ b/lib/Model/ScheduleSmtpEmail.php
@@ -185,7 +185,7 @@ class ScheduleSmtpEmail implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['messageId'] = isset($data['messageId']) ? $data['messageId'] : null;
         $this->container['messageIds'] = isset($data['messageIds']) ? $data['messageIds'] : null;

--- a/lib/Model/SendReport.php
+++ b/lib/Model/SendReport.php
@@ -203,7 +203,7 @@ class SendReport implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['language'] = isset($data['language']) ? $data['language'] : 'fr';
         $this->container['email'] = isset($data['email']) ? $data['email'] : null;

--- a/lib/Model/SendReportEmail.php
+++ b/lib/Model/SendReportEmail.php
@@ -181,7 +181,7 @@ class SendReportEmail implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['to'] = isset($data['to']) ? $data['to'] : null;
         $this->container['body'] = isset($data['body']) ? $data['body'] : null;

--- a/lib/Model/SendSms.php
+++ b/lib/Model/SendSms.php
@@ -192,7 +192,7 @@ class SendSms implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['reference'] = isset($data['reference']) ? $data['reference'] : null;
         $this->container['messageId'] = isset($data['messageId']) ? $data['messageId'] : null;

--- a/lib/Model/SendTestSms.php
+++ b/lib/Model/SendTestSms.php
@@ -172,7 +172,7 @@ class SendTestSms implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['phoneNumber'] = isset($data['phoneNumber']) ? $data['phoneNumber'] : null;
     }

--- a/lib/Model/SendTransacSms.php
+++ b/lib/Model/SendTransacSms.php
@@ -221,7 +221,7 @@ class SendTransacSms implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['sender'] = isset($data['sender']) ? $data['sender'] : null;
         $this->container['recipient'] = isset($data['recipient']) ? $data['recipient'] : null;

--- a/lib/Model/SendTransacSmsTag.php
+++ b/lib/Model/SendTransacSmsTag.php
@@ -173,7 +173,7 @@ class SendTransacSmsTag implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['field'] = isset($data['field']) ? $data['field'] : null;
     }

--- a/lib/Model/SendWhatsappMessage.php
+++ b/lib/Model/SendWhatsappMessage.php
@@ -195,7 +195,7 @@ class SendWhatsappMessage implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['templateId'] = isset($data['templateId']) ? $data['templateId'] : null;
         $this->container['text'] = isset($data['text']) ? $data['text'] : null;

--- a/lib/Model/SsoTokenRequest.php
+++ b/lib/Model/SsoTokenRequest.php
@@ -217,7 +217,7 @@ class SsoTokenRequest implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['email'] = isset($data['email']) ? $data['email'] : null;

--- a/lib/Model/SubAccountAppsToggleRequest.php
+++ b/lib/Model/SubAccountAppsToggleRequest.php
@@ -236,7 +236,7 @@ class SubAccountAppsToggleRequest implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['inbox'] = isset($data['inbox']) ? $data['inbox'] : null;
         $this->container['whatsapp'] = isset($data['whatsapp']) ? $data['whatsapp'] : null;

--- a/lib/Model/SubAccountDetailsResponse.php
+++ b/lib/Model/SubAccountDetailsResponse.php
@@ -190,7 +190,7 @@ class SubAccountDetailsResponse implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
         $this->container['email'] = isset($data['email']) ? $data['email'] : null;

--- a/lib/Model/SubAccountDetailsResponsePlanInfo.php
+++ b/lib/Model/SubAccountDetailsResponsePlanInfo.php
@@ -186,7 +186,7 @@ class SubAccountDetailsResponsePlanInfo implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['credits'] = isset($data['credits']) ? $data['credits'] : null;
         $this->container['features'] = isset($data['features']) ? $data['features'] : null;

--- a/lib/Model/SubAccountDetailsResponsePlanInfoCredits.php
+++ b/lib/Model/SubAccountDetailsResponsePlanInfoCredits.php
@@ -181,7 +181,7 @@ class SubAccountDetailsResponsePlanInfoCredits implements ModelInterface, ArrayA
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['sms'] = isset($data['sms']) ? $data['sms'] : null;
         $this->container['emails'] = isset($data['emails']) ? $data['emails'] : null;

--- a/lib/Model/SubAccountDetailsResponsePlanInfoCreditsEmails.php
+++ b/lib/Model/SubAccountDetailsResponsePlanInfoCreditsEmails.php
@@ -181,7 +181,7 @@ class SubAccountDetailsResponsePlanInfoCreditsEmails implements ModelInterface, 
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['quantity'] = isset($data['quantity']) ? $data['quantity'] : null;
         $this->container['remaining'] = isset($data['remaining']) ? $data['remaining'] : null;

--- a/lib/Model/SubAccountDetailsResponsePlanInfoFeatures.php
+++ b/lib/Model/SubAccountDetailsResponsePlanInfoFeatures.php
@@ -186,7 +186,7 @@ class SubAccountDetailsResponsePlanInfoFeatures implements ModelInterface, Array
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['inbox'] = isset($data['inbox']) ? $data['inbox'] : null;
         $this->container['landingPage'] = isset($data['landingPage']) ? $data['landingPage'] : null;

--- a/lib/Model/SubAccountDetailsResponsePlanInfoFeaturesInbox.php
+++ b/lib/Model/SubAccountDetailsResponsePlanInfoFeaturesInbox.php
@@ -181,7 +181,7 @@ class SubAccountDetailsResponsePlanInfoFeaturesInbox implements ModelInterface, 
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['quantity'] = isset($data['quantity']) ? $data['quantity'] : null;
         $this->container['remaining'] = isset($data['remaining']) ? $data['remaining'] : null;

--- a/lib/Model/SubAccountDetailsResponsePlanInfoFeaturesLandingPage.php
+++ b/lib/Model/SubAccountDetailsResponsePlanInfoFeaturesLandingPage.php
@@ -181,7 +181,7 @@ class SubAccountDetailsResponsePlanInfoFeaturesLandingPage implements ModelInter
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['quantity'] = isset($data['quantity']) ? $data['quantity'] : null;
         $this->container['remaining'] = isset($data['remaining']) ? $data['remaining'] : null;

--- a/lib/Model/SubAccountDetailsResponsePlanInfoFeaturesUsers.php
+++ b/lib/Model/SubAccountDetailsResponsePlanInfoFeaturesUsers.php
@@ -181,7 +181,7 @@ class SubAccountDetailsResponsePlanInfoFeaturesUsers implements ModelInterface, 
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['quantity'] = isset($data['quantity']) ? $data['quantity'] : null;
         $this->container['remaining'] = isset($data['remaining']) ? $data['remaining'] : null;

--- a/lib/Model/SubAccountUpdatePlanRequest.php
+++ b/lib/Model/SubAccountUpdatePlanRequest.php
@@ -181,7 +181,7 @@ class SubAccountUpdatePlanRequest implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['credits'] = isset($data['credits']) ? $data['credits'] : null;
         $this->container['features'] = isset($data['features']) ? $data['features'] : null;

--- a/lib/Model/SubAccountUpdatePlanRequestCredits.php
+++ b/lib/Model/SubAccountUpdatePlanRequestCredits.php
@@ -176,7 +176,7 @@ class SubAccountUpdatePlanRequestCredits implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['email'] = isset($data['email']) ? $data['email'] : null;
     }

--- a/lib/Model/SubAccountUpdatePlanRequestFeatures.php
+++ b/lib/Model/SubAccountUpdatePlanRequestFeatures.php
@@ -186,7 +186,7 @@ class SubAccountUpdatePlanRequestFeatures implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['users'] = isset($data['users']) ? $data['users'] : null;
         $this->container['landingPage'] = isset($data['landingPage']) ? $data['landingPage'] : null;

--- a/lib/Model/SubAccountsResponse.php
+++ b/lib/Model/SubAccountsResponse.php
@@ -180,7 +180,7 @@ class SubAccountsResponse implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['count'] = isset($data['count']) ? $data['count'] : null;
         $this->container['subAccounts'] = isset($data['subAccounts']) ? $data['subAccounts'] : null;

--- a/lib/Model/SubAccountsResponseSubAccounts.php
+++ b/lib/Model/SubAccountsResponseSubAccounts.php
@@ -190,7 +190,7 @@ class SubAccountsResponseSubAccounts implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['companyName'] = isset($data['companyName']) ? $data['companyName'] : null;

--- a/lib/Model/Task.php
+++ b/lib/Model/Task.php
@@ -201,7 +201,7 @@ class Task implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['taskTypeId'] = isset($data['taskTypeId']) ? $data['taskTypeId'] : null;

--- a/lib/Model/TaskList.php
+++ b/lib/Model/TaskList.php
@@ -176,7 +176,7 @@ class TaskList implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['items'] = isset($data['items']) ? $data['items'] : null;
     }

--- a/lib/Model/TaskReminder.php
+++ b/lib/Model/TaskReminder.php
@@ -205,7 +205,7 @@ class TaskReminder implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['value'] = isset($data['value']) ? $data['value'] : null;
         $this->container['unit'] = isset($data['unit']) ? $data['unit'] : null;

--- a/lib/Model/TaskTypes.php
+++ b/lib/Model/TaskTypes.php
@@ -181,7 +181,7 @@ class TaskTypes implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['title'] = isset($data['title']) ? $data['title'] : null;

--- a/lib/Model/UpdateAttribute.php
+++ b/lib/Model/UpdateAttribute.php
@@ -185,7 +185,7 @@ class UpdateAttribute implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['value'] = isset($data['value']) ? $data['value'] : null;
         $this->container['enumeration'] = isset($data['enumeration']) ? $data['enumeration'] : null;

--- a/lib/Model/UpdateAttributeEnumeration.php
+++ b/lib/Model/UpdateAttributeEnumeration.php
@@ -180,7 +180,7 @@ class UpdateAttributeEnumeration implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['value'] = isset($data['value']) ? $data['value'] : null;
         $this->container['label'] = isset($data['label']) ? $data['label'] : null;

--- a/lib/Model/UpdateBatchContacts.php
+++ b/lib/Model/UpdateBatchContacts.php
@@ -175,7 +175,7 @@ class UpdateBatchContacts implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['contacts'] = isset($data['contacts']) ? $data['contacts'] : null;
     }

--- a/lib/Model/UpdateBatchContactsContacts.php
+++ b/lib/Model/UpdateBatchContactsContacts.php
@@ -220,7 +220,7 @@ class UpdateBatchContactsContacts implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['email'] = isset($data['email']) ? $data['email'] : null;
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;

--- a/lib/Model/UpdateBatchContactsModel.php
+++ b/lib/Model/UpdateBatchContactsModel.php
@@ -180,7 +180,7 @@ class UpdateBatchContactsModel implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['successIds'] = isset($data['successIds']) ? $data['successIds'] : null;
         $this->container['failureIds'] = isset($data['failureIds']) ? $data['failureIds'] : null;

--- a/lib/Model/UpdateCampaignStatus.php
+++ b/lib/Model/UpdateCampaignStatus.php
@@ -203,7 +203,7 @@ class UpdateCampaignStatus implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['status'] = isset($data['status']) ? $data['status'] : null;
     }

--- a/lib/Model/UpdateChild.php
+++ b/lib/Model/UpdateChild.php
@@ -195,7 +195,7 @@ class UpdateChild implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['email'] = isset($data['email']) ? $data['email'] : null;
         $this->container['firstName'] = isset($data['firstName']) ? $data['firstName'] : null;

--- a/lib/Model/UpdateChildAccountStatus.php
+++ b/lib/Model/UpdateChildAccountStatus.php
@@ -190,7 +190,7 @@ class UpdateChildAccountStatus implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['transactionalEmail'] = isset($data['transactionalEmail']) ? $data['transactionalEmail'] : null;
         $this->container['transactionalSms'] = isset($data['transactionalSms']) ? $data['transactionalSms'] : null;

--- a/lib/Model/UpdateChildDomain.php
+++ b/lib/Model/UpdateChildDomain.php
@@ -175,7 +175,7 @@ class UpdateChildDomain implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['domain'] = isset($data['domain']) ? $data['domain'] : null;
     }

--- a/lib/Model/UpdateContact.php
+++ b/lib/Model/UpdateContact.php
@@ -202,7 +202,7 @@ class UpdateContact implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['attributes'] = isset($data['attributes']) ? $data['attributes'] : null;
         $this->container['extId'] = isset($data['extId']) ? $data['extId'] : null;

--- a/lib/Model/UpdateCouponCollection.php
+++ b/lib/Model/UpdateCouponCollection.php
@@ -175,7 +175,7 @@ class UpdateCouponCollection implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['defaultCoupon'] = isset($data['defaultCoupon']) ? $data['defaultCoupon'] : null;
     }

--- a/lib/Model/UpdateEmailCampaign.php
+++ b/lib/Model/UpdateEmailCampaign.php
@@ -340,7 +340,7 @@ class UpdateEmailCampaign implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['tag'] = isset($data['tag']) ? $data['tag'] : null;
         $this->container['sender'] = isset($data['sender']) ? $data['sender'] : null;

--- a/lib/Model/UpdateEmailCampaignRecipients.php
+++ b/lib/Model/UpdateEmailCampaignRecipients.php
@@ -186,7 +186,7 @@ class UpdateEmailCampaignRecipients implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['exclusionListIds'] = isset($data['exclusionListIds']) ? $data['exclusionListIds'] : null;
         $this->container['listIds'] = isset($data['listIds']) ? $data['listIds'] : null;

--- a/lib/Model/UpdateEmailCampaignSender.php
+++ b/lib/Model/UpdateEmailCampaignSender.php
@@ -186,7 +186,7 @@ class UpdateEmailCampaignSender implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
         $this->container['email'] = isset($data['email']) ? $data['email'] : null;

--- a/lib/Model/UpdateExternalFeed.php
+++ b/lib/Model/UpdateExternalFeed.php
@@ -232,7 +232,7 @@ class UpdateExternalFeed implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
         $this->container['url'] = isset($data['url']) ? $data['url'] : null;

--- a/lib/Model/UpdateList.php
+++ b/lib/Model/UpdateList.php
@@ -180,7 +180,7 @@ class UpdateList implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
         $this->container['folderId'] = isset($data['folderId']) ? $data['folderId'] : null;

--- a/lib/Model/UpdateSender.php
+++ b/lib/Model/UpdateSender.php
@@ -185,7 +185,7 @@ class UpdateSender implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
         $this->container['email'] = isset($data['email']) ? $data['email'] : null;

--- a/lib/Model/UpdateSmsCampaign.php
+++ b/lib/Model/UpdateSmsCampaign.php
@@ -210,7 +210,7 @@ class UpdateSmsCampaign implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
         $this->container['sender'] = isset($data['sender']) ? $data['sender'] : null;

--- a/lib/Model/UpdateSmtpTemplate.php
+++ b/lib/Model/UpdateSmtpTemplate.php
@@ -220,7 +220,7 @@ class UpdateSmtpTemplate implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['tag'] = isset($data['tag']) ? $data['tag'] : null;
         $this->container['sender'] = isset($data['sender']) ? $data['sender'] : null;

--- a/lib/Model/UpdateSmtpTemplateSender.php
+++ b/lib/Model/UpdateSmtpTemplateSender.php
@@ -186,7 +186,7 @@ class UpdateSmtpTemplateSender implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
         $this->container['email'] = isset($data['email']) ? $data['email'] : null;

--- a/lib/Model/UpdateWebhook.php
+++ b/lib/Model/UpdateWebhook.php
@@ -250,7 +250,7 @@ class UpdateWebhook implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['url'] = isset($data['url']) ? $data['url'] : null;
         $this->container['description'] = isset($data['description']) ? $data['description'] : null;

--- a/lib/Model/UpdateWhatsAppCampaign.php
+++ b/lib/Model/UpdateWhatsAppCampaign.php
@@ -205,7 +205,7 @@ class UpdateWhatsAppCampaign implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['campaignName'] = isset($data['campaignName']) ? $data['campaignName'] : null;
         $this->container['campaignStatus'] = isset($data['campaignStatus']) ? $data['campaignStatus'] : 'scheduled';

--- a/lib/Model/UploadImageModel.php
+++ b/lib/Model/UploadImageModel.php
@@ -175,7 +175,7 @@ class UploadImageModel implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['url'] = isset($data['url']) ? $data['url'] : null;
     }

--- a/lib/Model/UploadImageToGallery.php
+++ b/lib/Model/UploadImageToGallery.php
@@ -180,7 +180,7 @@ class UploadImageToGallery implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['imageUrl'] = isset($data['imageUrl']) ? $data['imageUrl'] : null;
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;

--- a/lib/Model/VariablesItems.php
+++ b/lib/Model/VariablesItems.php
@@ -185,7 +185,7 @@ class VariablesItems implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
         $this->container['default'] = isset($data['default']) ? $data['default'] : null;

--- a/lib/Model/WhatsappCampStats.php
+++ b/lib/Model/WhatsappCampStats.php
@@ -195,7 +195,7 @@ class WhatsappCampStats implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['sent'] = isset($data['sent']) ? $data['sent'] : null;
         $this->container['delivered'] = isset($data['delivered']) ? $data['delivered'] : null;

--- a/lib/Model/WhatsappCampTemplate.php
+++ b/lib/Model/WhatsappCampTemplate.php
@@ -225,7 +225,7 @@ class WhatsappCampTemplate implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
         $this->container['category'] = isset($data['category']) ? $data['category'] : null;


### PR DESCRIPTION
Replaced
`(array $data = null)`
with
`(?array $data = null)`
to fix deprecation warnings due to php 8.4 on implicitly nullable parameters