### PR TITLE
fix: createContact deserialization on empty success response

### DIFF
--- a/src/Contacts/ContactsClient.php
+++ b/src/Contacts/ContactsClient.php
@@ -200,6 +200,9 @@ class ContactsClient implements ContactsClientInterface
             $statusCode = $response->getStatusCode();
             if ($statusCode >= 200 && $statusCode < 400) {
                 $json = $response->getBody()->getContents();
+                if (empty($json)) {
+                    return new CreateContactResponse();
+                }
                 return CreateContactResponse::fromJson($json);
             }
         } catch (JsonException $e) {

--- a/tests/Contacts/ContactsClientTest.php
+++ b/tests/Contacts/ContactsClientTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Brevo\Tests\Contacts;
+
+use PHPUnit\Framework\TestCase;
+use Brevo\Contacts\ContactsClient;
+use Brevo\Core\Client\RawClient;
+use Brevo\Contacts\Requests\CreateContactRequest;
+use Brevo\Contacts\Types\CreateContactResponse;
+use Brevo\Exceptions\BrevoException;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
+
+class ContactsClientTest extends TestCase
+{
+    private $rawClientMock;
+    private $contactsClient;
+
+    protected function setUp(): void
+    {
+        $this->rawClientMock = $this->createMock(RawClient::class);
+        $this->contactsClient = new ContactsClient($this->rawClientMock);
+    }
+
+    public function testCreateContactWithEmptyResponseSucceeds(): void
+    {
+        $responseMock = $this->createMock(ResponseInterface::class);
+        $streamMock = $this->createMock(StreamInterface::class);
+
+        $responseMock->method('getStatusCode')->willReturn(201);
+        $responseMock->method('getBody')->willReturn($streamMock);
+        $streamMock->method('getContents')->willReturn('');
+
+        $this->rawClientMock->method('sendRequest')->willReturn($responseMock);
+
+        $response = $this->contactsClient->createContact(new CreateContactRequest());
+
+        $this->assertInstanceOf(CreateContactResponse::class, $response);
+        $this->assertNull($response->id);
+    }
+
+    public function testCreateContactWithValidJsonResponse(): void
+    {
+        $responseMock = $this->createMock(ResponseInterface::class);
+        $streamMock = $this->createMock(StreamInterface::class);
+
+        $responseMock->method('getStatusCode')->willReturn(201);
+        $responseMock->method('getBody')->willReturn($streamMock);
+        $streamMock->method('getContents')->willReturn('{"id": 123}');
+
+        $this->rawClientMock->method('sendRequest')->willReturn($responseMock);
+
+        $response = $this->contactsClient->createContact(new CreateContactRequest());
+
+        $this->assertInstanceOf(CreateContactResponse::class, $response);
+        $this->assertEquals(123, $response->id);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes a bug where `ContactsClient::createContact()` could throw:

`Brevo\Exceptions\BrevoException: Failed to deserialize response: Syntax error`

when the API returned a successful response with an empty or blank body.

## Root cause

`createContact()` attempted to deserialize every successful response body
as JSON without checking whether the body was empty first.

## Changes

- added a regression test covering a successful empty response body
- updated `ContactsClient::createContact()` to handle empty successful responses safely
- preserved existing behavior for normal valid JSON responses

## Result

`createContact()` no longer throws a JSON syntax error for empty success
responses and remains compatible with the current method contract.

Resolves: https://github.com/getbrevo/brevo-php/issues/104