### PR TITLE
Define PHP version requirement to 7.2 or higher

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         }
     ],
     "require": {
-        "php": ">=5.6",
+        "php": ">=7.2",
         "ext-curl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",


### PR DESCRIPTION
Brevo is built on top of guzzlehttp/guzzle 7.4 which min requirements is PHP 7.2.5:

https://github.com/guzzle/guzzle/blob/868b3571a039f0ebc11ac8f344f4080babe2cb94/composer.json#L54