### PR TITLE
deprecation(php): Fix PHP8.4 deprecations

### DIFF
--- a/lib/Api/AccountApi.php
+++ b/lib/Api/AccountApi.php
@@ -70,9 +70,9 @@ class AccountApi
      * @param HeaderSelector  $selector
      */
     public function __construct(
-        ClientInterface $client = null,
-        Configuration $config = null,
-        HeaderSelector $selector = null
+        ?ClientInterface $client = null,
+        ?Configuration $config = null,
+        ?HeaderSelector $selector = null
     ) {
         $this->client = $client ?: new Client();
         $this->config = $config ?: new Configuration();

--- a/lib/Api/AttributesApi.php
+++ b/lib/Api/AttributesApi.php
@@ -70,9 +70,9 @@ class AttributesApi
      * @param HeaderSelector  $selector
      */
     public function __construct(
-        ClientInterface $client = null,
-        Configuration $config = null,
-        HeaderSelector $selector = null
+        ?ClientInterface $client = null,
+        ?Configuration $config = null,
+        ?HeaderSelector $selector = null
     ) {
         $this->client = $client ?: new Client();
         $this->config = $config ?: new Configuration();

--- a/lib/Api/CRMApi.php
+++ b/lib/Api/CRMApi.php
@@ -70,9 +70,9 @@ class CRMApi
      * @param HeaderSelector  $selector
      */
     public function __construct(
-        ClientInterface $client = null,
-        Configuration $config = null,
-        HeaderSelector $selector = null
+        ?ClientInterface $client = null,
+        ?Configuration $config = null,
+        ?HeaderSelector $selector = null
     ) {
         $this->client = $client ?: new Client();
         $this->config = $config ?: new Configuration();

--- a/lib/Api/CompaniesApi.php
+++ b/lib/Api/CompaniesApi.php
@@ -70,9 +70,9 @@ class CompaniesApi
      * @param HeaderSelector  $selector
      */
     public function __construct(
-        ClientInterface $client = null,
-        Configuration $config = null,
-        HeaderSelector $selector = null
+        ?ClientInterface $client = null,
+        ?Configuration $config = null,
+        ?HeaderSelector $selector = null
     ) {
         $this->client = $client ?: new Client();
         $this->config = $config ?: new Configuration();

--- a/lib/Api/ConversationsApi.php
+++ b/lib/Api/ConversationsApi.php
@@ -70,9 +70,9 @@ class ConversationsApi
      * @param HeaderSelector  $selector
      */
     public function __construct(
-        ClientInterface $client = null,
-        Configuration $config = null,
-        HeaderSelector $selector = null
+        ?ClientInterface $client = null,
+        ?Configuration $config = null,
+        ?HeaderSelector $selector = null
     ) {
         $this->client = $client ?: new Client();
         $this->config = $config ?: new Configuration();

--- a/lib/Api/CouponsApi.php
+++ b/lib/Api/CouponsApi.php
@@ -70,9 +70,9 @@ class CouponsApi
      * @param HeaderSelector  $selector
      */
     public function __construct(
-        ClientInterface $client = null,
-        Configuration $config = null,
-        HeaderSelector $selector = null
+        ?ClientInterface $client = null,
+        ?Configuration $config = null,
+        ?HeaderSelector $selector = null
     ) {
         $this->client = $client ?: new Client();
         $this->config = $config ?: new Configuration();

--- a/lib/Api/DealsApi.php
+++ b/lib/Api/DealsApi.php
@@ -70,9 +70,9 @@ class DealsApi
      * @param HeaderSelector  $selector
      */
     public function __construct(
-        ClientInterface $client = null,
-        Configuration $config = null,
-        HeaderSelector $selector = null
+        ?ClientInterface $client = null,
+        ?Configuration $config = null,
+        ?HeaderSelector $selector = null
     ) {
         $this->client = $client ?: new Client();
         $this->config = $config ?: new Configuration();

--- a/lib/Api/DomainsApi.php
+++ b/lib/Api/DomainsApi.php
@@ -70,9 +70,9 @@ class DomainsApi
      * @param HeaderSelector  $selector
      */
     public function __construct(
-        ClientInterface $client = null,
-        Configuration $config = null,
-        HeaderSelector $selector = null
+        ?ClientInterface $client = null,
+        ?Configuration $config = null,
+        ?HeaderSelector $selector = null
     ) {
         $this->client = $client ?: new Client();
         $this->config = $config ?: new Configuration();

--- a/lib/Api/EcommerceApi.php
+++ b/lib/Api/EcommerceApi.php
@@ -70,9 +70,9 @@ class EcommerceApi
      * @param HeaderSelector  $selector
      */
     public function __construct(
-        ClientInterface $client = null,
-        Configuration $config = null,
-        HeaderSelector $selector = null
+        ?ClientInterface $client = null,
+        ?Configuration $config = null,
+        ?HeaderSelector $selector = null
     ) {
         $this->client = $client ?: new Client();
         $this->config = $config ?: new Configuration();

--- a/lib/Api/EventsApi.php
+++ b/lib/Api/EventsApi.php
@@ -70,9 +70,9 @@ class EventsApi
      * @param HeaderSelector  $selector
      */
     public function __construct(
-        ClientInterface $client = null,
-        Configuration $config = null,
-        HeaderSelector $selector = null
+        ?ClientInterface $client = null,
+        ?Configuration $config = null,
+        ?HeaderSelector $selector = null
     ) {
         $this->client = $client ?: new Client();
         $this->config = $config ?: new Configuration();

--- a/lib/Api/ExternalFeedsApi.php
+++ b/lib/Api/ExternalFeedsApi.php
@@ -70,9 +70,9 @@ class ExternalFeedsApi
      * @param HeaderSelector  $selector
      */
     public function __construct(
-        ClientInterface $client = null,
-        Configuration $config = null,
-        HeaderSelector $selector = null
+        ?ClientInterface $client = null,
+        ?Configuration $config = null,
+        ?HeaderSelector $selector = null
     ) {
         $this->client = $client ?: new Client();
         $this->config = $config ?: new Configuration();

--- a/lib/Api/FilesApi.php
+++ b/lib/Api/FilesApi.php
@@ -70,9 +70,9 @@ class FilesApi
      * @param HeaderSelector  $selector
      */
     public function __construct(
-        ClientInterface $client = null,
-        Configuration $config = null,
-        HeaderSelector $selector = null
+        ?ClientInterface $client = null,
+        ?Configuration $config = null,
+        ?HeaderSelector $selector = null
     ) {
         $this->client = $client ?: new Client();
         $this->config = $config ?: new Configuration();

--- a/lib/Api/FoldersApi.php
+++ b/lib/Api/FoldersApi.php
@@ -70,9 +70,9 @@ class FoldersApi
      * @param HeaderSelector  $selector
      */
     public function __construct(
-        ClientInterface $client = null,
-        Configuration $config = null,
-        HeaderSelector $selector = null
+        ?ClientInterface $client = null,
+        ?Configuration $config = null,
+        ?HeaderSelector $selector = null
     ) {
         $this->client = $client ?: new Client();
         $this->config = $config ?: new Configuration();

--- a/lib/Api/InboundParsingApi.php
+++ b/lib/Api/InboundParsingApi.php
@@ -70,9 +70,9 @@ class InboundParsingApi
      * @param HeaderSelector  $selector
      */
     public function __construct(
-        ClientInterface $client = null,
-        Configuration $config = null,
-        HeaderSelector $selector = null
+        ?ClientInterface $client = null,
+        ?Configuration $config = null,
+        ?HeaderSelector $selector = null
     ) {
         $this->client = $client ?: new Client();
         $this->config = $config ?: new Configuration();

--- a/lib/Api/ListsApi.php
+++ b/lib/Api/ListsApi.php
@@ -70,9 +70,9 @@ class ListsApi
      * @param HeaderSelector  $selector
      */
     public function __construct(
-        ClientInterface $client = null,
-        Configuration $config = null,
-        HeaderSelector $selector = null
+        ?ClientInterface $client = null,
+        ?Configuration $config = null,
+        ?HeaderSelector $selector = null
     ) {
         $this->client = $client ?: new Client();
         $this->config = $config ?: new Configuration();

--- a/lib/Api/MasterAccountApi.php
+++ b/lib/Api/MasterAccountApi.php
@@ -70,9 +70,9 @@ class MasterAccountApi
      * @param HeaderSelector  $selector
      */
     public function __construct(
-        ClientInterface $client = null,
-        Configuration $config = null,
-        HeaderSelector $selector = null
+        ?ClientInterface $client = null,
+        ?Configuration $config = null,
+        ?HeaderSelector $selector = null
     ) {
         $this->client = $client ?: new Client();
         $this->config = $config ?: new Configuration();

--- a/lib/Api/NotesApi.php
+++ b/lib/Api/NotesApi.php
@@ -70,9 +70,9 @@ class NotesApi
      * @param HeaderSelector  $selector
      */
     public function __construct(
-        ClientInterface $client = null,
-        Configuration $config = null,
-        HeaderSelector $selector = null
+        ?ClientInterface $client = null,
+        ?Configuration $config = null,
+        ?HeaderSelector $selector = null
     ) {
         $this->client = $client ?: new Client();
         $this->config = $config ?: new Configuration();

--- a/lib/Api/ProcessApi.php
+++ b/lib/Api/ProcessApi.php
@@ -70,9 +70,9 @@ class ProcessApi
      * @param HeaderSelector  $selector
      */
     public function __construct(
-        ClientInterface $client = null,
-        Configuration $config = null,
-        HeaderSelector $selector = null
+        ?ClientInterface $client = null,
+        ?Configuration $config = null,
+        ?HeaderSelector $selector = null
     ) {
         $this->client = $client ?: new Client();
         $this->config = $config ?: new Configuration();

--- a/lib/Api/ResellerApi.php
+++ b/lib/Api/ResellerApi.php
@@ -70,9 +70,9 @@ class ResellerApi
      * @param HeaderSelector  $selector
      */
     public function __construct(
-        ClientInterface $client = null,
-        Configuration $config = null,
-        HeaderSelector $selector = null
+        ?ClientInterface $client = null,
+        ?Configuration $config = null,
+        ?HeaderSelector $selector = null
     ) {
         $this->client = $client ?: new Client();
         $this->config = $config ?: new Configuration();

--- a/lib/Api/SMSCampaignsApi.php
+++ b/lib/Api/SMSCampaignsApi.php
@@ -70,9 +70,9 @@ class SMSCampaignsApi
      * @param HeaderSelector  $selector
      */
     public function __construct(
-        ClientInterface $client = null,
-        Configuration $config = null,
-        HeaderSelector $selector = null
+        ?ClientInterface $client = null,
+        ?Configuration $config = null,
+        ?HeaderSelector $selector = null
     ) {
         $this->client = $client ?: new Client();
         $this->config = $config ?: new Configuration();

--- a/lib/Api/SendersApi.php
+++ b/lib/Api/SendersApi.php
@@ -70,9 +70,9 @@ class SendersApi
      * @param HeaderSelector  $selector
      */
     public function __construct(
-        ClientInterface $client = null,
-        Configuration $config = null,
-        HeaderSelector $selector = null
+        ?ClientInterface $client = null,
+        ?Configuration $config = null,
+        ?HeaderSelector $selector = null
     ) {
         $this->client = $client ?: new Client();
         $this->config = $config ?: new Configuration();

--- a/lib/Api/TasksApi.php
+++ b/lib/Api/TasksApi.php
@@ -70,9 +70,9 @@ class TasksApi
      * @param HeaderSelector  $selector
      */
     public function __construct(
-        ClientInterface $client = null,
-        Configuration $config = null,
-        HeaderSelector $selector = null
+        ?ClientInterface $client = null,
+        ?Configuration $config = null,
+        ?HeaderSelector $selector = null
     ) {
         $this->client = $client ?: new Client();
         $this->config = $config ?: new Configuration();

--- a/lib/Api/TransactionalSMSApi.php
+++ b/lib/Api/TransactionalSMSApi.php
@@ -69,9 +69,9 @@ class TransactionalSMSApi
      * @param HeaderSelector  $selector
      */
     public function __construct(
-        ClientInterface $client = null,
-        Configuration $config = null,
-        HeaderSelector $selector = null
+        ?ClientInterface $client = null,
+        ?Configuration $config = null,
+        ?HeaderSelector $selector = null
     ) {
         $this->client = $client ?: new Client();
         $this->config = $config ?: new Configuration();

--- a/lib/Api/UserApi.php
+++ b/lib/Api/UserApi.php
@@ -70,9 +70,9 @@ class UserApi
      * @param HeaderSelector  $selector
      */
     public function __construct(
-        ClientInterface $client = null,
-        Configuration $config = null,
-        HeaderSelector $selector = null
+        ?ClientInterface $client = null,
+        ?Configuration $config = null,
+        ?HeaderSelector $selector = null
     ) {
         $this->client = $client ?: new Client();
         $this->config = $config ?: new Configuration();

--- a/lib/Api/WebhooksApi.php
+++ b/lib/Api/WebhooksApi.php
@@ -70,9 +70,9 @@ class WebhooksApi
      * @param HeaderSelector  $selector
      */
     public function __construct(
-        ClientInterface $client = null,
-        Configuration $config = null,
-        HeaderSelector $selector = null
+        ?ClientInterface $client = null,
+        ?Configuration $config = null,
+        ?HeaderSelector $selector = null
     ) {
         $this->client = $client ?: new Client();
         $this->config = $config ?: new Configuration();

--- a/lib/Api/WhatsAppCampaignsApi.php
+++ b/lib/Api/WhatsAppCampaignsApi.php
@@ -70,9 +70,9 @@ class WhatsAppCampaignsApi
      * @param HeaderSelector  $selector
      */
     public function __construct(
-        ClientInterface $client = null,
-        Configuration $config = null,
-        HeaderSelector $selector = null
+        ?ClientInterface $client = null,
+        ?Configuration $config = null,
+        ?HeaderSelector $selector = null
     ) {
         $this->client = $client ?: new Client();
         $this->config = $config ?: new Configuration();

--- a/lib/Model/AbTestCampaignResult.php
+++ b/lib/Model/AbTestCampaignResult.php
@@ -246,7 +246,7 @@ class AbTestCampaignResult implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['winningVersion'] = isset($data['winningVersion']) ? $data['winningVersion'] : null;
         $this->container['winningCriteria'] = isset($data['winningCriteria']) ? $data['winningCriteria'] : null;
@@ -581,5 +581,3 @@ class AbTestCampaignResult implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/AbTestCampaignResultClickedLinks.php
+++ b/lib/Model/AbTestCampaignResultClickedLinks.php
@@ -180,7 +180,7 @@ class AbTestCampaignResultClickedLinks implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['versionA'] = isset($data['versionA']) ? $data['versionA'] : null;
         $this->container['versionB'] = isset($data['versionB']) ? $data['versionB'] : null;
@@ -337,5 +337,3 @@ class AbTestCampaignResultClickedLinks implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/AbTestCampaignResultStatistics.php
+++ b/lib/Model/AbTestCampaignResultStatistics.php
@@ -200,7 +200,7 @@ class AbTestCampaignResultStatistics implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['openers'] = isset($data['openers']) ? $data['openers'] : null;
         $this->container['clicks'] = isset($data['clicks']) ? $data['clicks'] : null;
@@ -469,5 +469,3 @@ class AbTestCampaignResultStatistics implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/AbTestVersionClicks.php
+++ b/lib/Model/AbTestVersionClicks.php
@@ -176,7 +176,7 @@ class AbTestVersionClicks implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
     }
 
@@ -277,5 +277,3 @@ class AbTestVersionClicks implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/AbTestVersionClicksInner.php
+++ b/lib/Model/AbTestVersionClicksInner.php
@@ -185,7 +185,7 @@ class AbTestVersionClicksInner implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['link'] = isset($data['link']) ? $data['link'] : null;
         $this->container['clicksCount'] = isset($data['clicksCount']) ? $data['clicksCount'] : null;
@@ -370,5 +370,3 @@ class AbTestVersionClicksInner implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/AbTestVersionStats.php
+++ b/lib/Model/AbTestVersionStats.php
@@ -181,7 +181,7 @@ class AbTestVersionStats implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['versionA'] = isset($data['versionA']) ? $data['versionA'] : null;
         $this->container['versionB'] = isset($data['versionB']) ? $data['versionB'] : null;
@@ -338,5 +338,3 @@ class AbTestVersionStats implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/AddChildDomain.php
+++ b/lib/Model/AddChildDomain.php
@@ -175,7 +175,7 @@ class AddChildDomain implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['domain'] = isset($data['domain']) ? $data['domain'] : null;
     }
@@ -301,5 +301,3 @@ class AddChildDomain implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/AddContactToList.php
+++ b/lib/Model/AddContactToList.php
@@ -180,7 +180,7 @@ class AddContactToList implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['emails'] = isset($data['emails']) ? $data['emails'] : null;
         $this->container['ids'] = isset($data['ids']) ? $data['ids'] : null;
@@ -331,5 +331,3 @@ class AddContactToList implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/AddCredits.php
+++ b/lib/Model/AddCredits.php
@@ -180,7 +180,7 @@ class AddCredits implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['sms'] = isset($data['sms']) ? $data['sms'] : null;
         $this->container['email'] = isset($data['email']) ? $data['email'] : null;
@@ -331,5 +331,3 @@ class AddCredits implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/AllOfgetContactsContactsItems.php
+++ b/lib/Model/AllOfgetContactsContactsItems.php
@@ -159,7 +159,7 @@ class AllOfgetContactsContactsItems extends GetContactDetails
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         parent::__construct($data);
 

--- a/lib/Model/AllOfgetEmailCampaignsCampaignsItems.php
+++ b/lib/Model/AllOfgetEmailCampaignsCampaignsItems.php
@@ -174,7 +174,7 @@ class AllOfgetEmailCampaignsCampaignsItems extends GetExtendedCampaignOverview
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         parent::__construct($data);
 

--- a/lib/Model/AuthenticateDomainModel.php
+++ b/lib/Model/AuthenticateDomainModel.php
@@ -180,7 +180,7 @@ class AuthenticateDomainModel implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['domainName'] = isset($data['domainName']) ? $data['domainName'] : null;
         $this->container['message'] = isset($data['message']) ? $data['message'] : null;
@@ -337,5 +337,3 @@ class AuthenticateDomainModel implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/BlockDomain.php
+++ b/lib/Model/BlockDomain.php
@@ -175,7 +175,7 @@ class BlockDomain implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['domain'] = isset($data['domain']) ? $data['domain'] : null;
     }
@@ -304,5 +304,3 @@ class BlockDomain implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/Body.php
+++ b/lib/Model/Body.php
@@ -180,7 +180,7 @@ class Body implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['groupName'] = isset($data['groupName']) ? $data['groupName'] : null;
         $this->container['subAccountIds'] = isset($data['subAccountIds']) ? $data['subAccountIds'] : null;
@@ -334,5 +334,3 @@ class Body implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/Body1.php
+++ b/lib/Model/Body1.php
@@ -180,7 +180,7 @@ class Body1 implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['groupName'] = isset($data['groupName']) ? $data['groupName'] : null;
         $this->container['subAccountIds'] = isset($data['subAccountIds']) ? $data['subAccountIds'] : null;
@@ -334,5 +334,3 @@ class Body1 implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/Body10.php
+++ b/lib/Model/Body10.php
@@ -200,7 +200,7 @@ class Body10 implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['visitorId'] = isset($data['visitorId']) ? $data['visitorId'] : null;
         $this->container['text'] = isset($data['text']) ? $data['text'] : null;
@@ -457,5 +457,3 @@ class Body10 implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/Body11.php
+++ b/lib/Model/Body11.php
@@ -175,7 +175,7 @@ class Body11 implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['text'] = isset($data['text']) ? $data['text'] : null;
     }
@@ -304,5 +304,3 @@ class Body11 implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/Body12.php
+++ b/lib/Model/Body12.php
@@ -190,7 +190,7 @@ class Body12 implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['visitorId'] = isset($data['visitorId']) ? $data['visitorId'] : null;
         $this->container['text'] = isset($data['text']) ? $data['text'] : null;
@@ -397,5 +397,3 @@ class Body12 implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/Body13.php
+++ b/lib/Model/Body13.php
@@ -175,7 +175,7 @@ class Body13 implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['text'] = isset($data['text']) ? $data['text'] : null;
     }
@@ -304,5 +304,3 @@ class Body13 implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/Body14.php
+++ b/lib/Model/Body14.php
@@ -190,7 +190,7 @@ class Body14 implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['agentId'] = isset($data['agentId']) ? $data['agentId'] : null;
         $this->container['receivedFrom'] = isset($data['receivedFrom']) ? $data['receivedFrom'] : null;
@@ -391,5 +391,3 @@ class Body14 implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/Body2.php
+++ b/lib/Model/Body2.php
@@ -185,7 +185,7 @@ class Body2 implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
         $this->container['attributes'] = isset($data['attributes']) ? $data['attributes'] : null;
@@ -364,5 +364,3 @@ class Body2 implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/Body3.php
+++ b/lib/Model/Body3.php
@@ -185,7 +185,7 @@ class Body3 implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
         $this->container['attributes'] = isset($data['attributes']) ? $data['attributes'] : null;
@@ -361,5 +361,3 @@ class Body3 implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/Body4.php
+++ b/lib/Model/Body4.php
@@ -190,7 +190,7 @@ class Body4 implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['linkContactIds'] = isset($data['linkContactIds']) ? $data['linkContactIds'] : null;
         $this->container['unlinkContactIds'] = isset($data['unlinkContactIds']) ? $data['unlinkContactIds'] : null;
@@ -391,5 +391,3 @@ class Body4 implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/Body5.php
+++ b/lib/Model/Body5.php
@@ -180,7 +180,7 @@ class Body5 implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
         $this->container['attributes'] = isset($data['attributes']) ? $data['attributes'] : null;
@@ -334,5 +334,3 @@ class Body5 implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/Body6.php
+++ b/lib/Model/Body6.php
@@ -180,7 +180,7 @@ class Body6 implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
         $this->container['attributes'] = isset($data['attributes']) ? $data['attributes'] : null;
@@ -331,5 +331,3 @@ class Body6 implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/Body7.php
+++ b/lib/Model/Body7.php
@@ -190,7 +190,7 @@ class Body7 implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['linkContactIds'] = isset($data['linkContactIds']) ? $data['linkContactIds'] : null;
         $this->container['unlinkContactIds'] = isset($data['unlinkContactIds']) ? $data['unlinkContactIds'] : null;
@@ -391,5 +391,3 @@ class Body7 implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/Body8.php
+++ b/lib/Model/Body8.php
@@ -225,7 +225,7 @@ class Body8 implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
         $this->container['duration'] = isset($data['duration']) ? $data['duration'] : null;
@@ -619,5 +619,3 @@ class Body8 implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/Body9.php
+++ b/lib/Model/Body9.php
@@ -220,7 +220,7 @@ class Body9 implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
         $this->container['duration'] = isset($data['duration']) ? $data['duration'] : null;
@@ -571,5 +571,3 @@ class Body9 implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/BodyVariablesItems.php
+++ b/lib/Model/BodyVariablesItems.php
@@ -175,7 +175,7 @@ class BodyVariablesItems implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
     }
 
@@ -276,5 +276,3 @@ class BodyVariablesItems implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/CompaniesList.php
+++ b/lib/Model/CompaniesList.php
@@ -176,7 +176,7 @@ class CompaniesList implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['items'] = isset($data['items']) ? $data['items'] : null;
     }
@@ -302,5 +302,3 @@ class CompaniesList implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/Company.php
+++ b/lib/Model/Company.php
@@ -191,7 +191,7 @@ class Company implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['attributes'] = isset($data['attributes']) ? $data['attributes'] : null;
@@ -392,5 +392,3 @@ class Company implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/CompanyAttributes.php
+++ b/lib/Model/CompanyAttributes.php
@@ -176,7 +176,7 @@ class CompanyAttributes implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
     }
 
@@ -277,5 +277,3 @@ class CompanyAttributes implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/CompanyAttributesInner.php
+++ b/lib/Model/CompanyAttributesInner.php
@@ -196,7 +196,7 @@ class CompanyAttributesInner implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['internalName'] = isset($data['internalName']) ? $data['internalName'] : null;
         $this->container['label'] = isset($data['label']) ? $data['label'] : null;
@@ -422,5 +422,3 @@ class CompanyAttributesInner implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/ComponentItems.php
+++ b/lib/Model/ComponentItems.php
@@ -180,7 +180,7 @@ class ComponentItems implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['type'] = isset($data['type']) ? $data['type'] : null;
         $this->container['text'] = isset($data['text']) ? $data['text'] : null;
@@ -331,5 +331,3 @@ class ComponentItems implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/Contact.php
+++ b/lib/Model/Contact.php
@@ -211,7 +211,7 @@ class Contact implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['virtualNextTask'] = isset($data['virtualNextTask']) ? $data['virtualNextTask'] : null;
         $this->container['email'] = isset($data['email']) ? $data['email'] : null;
@@ -451,6 +451,7 @@ class Contact implements ModelInterface, ArrayAccess
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -463,6 +464,7 @@ class Contact implements ModelInterface, ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
@@ -476,6 +478,7 @@ class Contact implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -492,6 +495,7 @@ class Contact implements ModelInterface, ArrayAccess
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -514,5 +518,3 @@ class Contact implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/ContactErrorModel.php
+++ b/lib/Model/ContactErrorModel.php
@@ -206,7 +206,7 @@ class ContactErrorModel implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['code'] = isset($data['code']) ? $data['code'] : null;
         $this->container['message'] = isset($data['message']) ? $data['message'] : null;

--- a/lib/Model/ConversationsMessage.php
+++ b/lib/Model/ConversationsMessage.php
@@ -236,7 +236,7 @@ class ConversationsMessage implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['type'] = isset($data['type']) ? $data['type'] : null;
@@ -613,5 +613,3 @@ class ConversationsMessage implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/ConversationsMessageFile.php
+++ b/lib/Model/ConversationsMessageFile.php
@@ -195,7 +195,7 @@ class ConversationsMessageFile implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['filename'] = isset($data['filename']) ? $data['filename'] : null;
         $this->container['size'] = isset($data['size']) ? $data['size'] : null;
@@ -430,5 +430,3 @@ class ConversationsMessageFile implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/ConversationsMessageFileImageInfo.php
+++ b/lib/Model/ConversationsMessageFileImageInfo.php
@@ -186,7 +186,7 @@ class ConversationsMessageFileImageInfo implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['width'] = isset($data['width']) ? $data['width'] : null;
         $this->container['height'] = isset($data['height']) ? $data['height'] : null;
@@ -380,5 +380,3 @@ class ConversationsMessageFileImageInfo implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/CreateApiKeyRequest.php
+++ b/lib/Model/CreateApiKeyRequest.php
@@ -180,7 +180,7 @@ class CreateApiKeyRequest implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
@@ -334,5 +334,3 @@ class CreateApiKeyRequest implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/CreateApiKeyResponse.php
+++ b/lib/Model/CreateApiKeyResponse.php
@@ -180,7 +180,7 @@ class CreateApiKeyResponse implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['status'] = isset($data['status']) ? $data['status'] : null;
         $this->container['key'] = isset($data['key']) ? $data['key'] : null;
@@ -331,5 +331,3 @@ class CreateApiKeyResponse implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/CreateAttribute.php
+++ b/lib/Model/CreateAttribute.php
@@ -220,7 +220,7 @@ class CreateAttribute implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['value'] = isset($data['value']) ? $data['value'] : null;
         $this->container['isRecurring'] = isset($data['isRecurring']) ? $data['isRecurring'] : null;
@@ -463,5 +463,3 @@ class CreateAttribute implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/CreateAttributeEnumeration.php
+++ b/lib/Model/CreateAttributeEnumeration.php
@@ -180,7 +180,7 @@ class CreateAttributeEnumeration implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['value'] = isset($data['value']) ? $data['value'] : null;
         $this->container['label'] = isset($data['label']) ? $data['label'] : null;
@@ -337,5 +337,3 @@ class CreateAttributeEnumeration implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/CreateCategoryModel.php
+++ b/lib/Model/CreateCategoryModel.php
@@ -175,7 +175,7 @@ class CreateCategoryModel implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
     }
@@ -301,5 +301,3 @@ class CreateCategoryModel implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/CreateChild.php
+++ b/lib/Model/CreateChild.php
@@ -223,7 +223,7 @@ class CreateChild implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['email'] = isset($data['email']) ? $data['email'] : null;
         $this->container['firstName'] = isset($data['firstName']) ? $data['firstName'] : null;
@@ -506,5 +506,3 @@ class CreateChild implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/CreateContact.php
+++ b/lib/Model/CreateContact.php
@@ -207,7 +207,7 @@ class CreateContact implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['email'] = isset($data['email']) ? $data['email'] : null;
         $this->container['extId'] = isset($data['extId']) ? $data['extId'] : null;

--- a/lib/Model/CreateCouponCollection.php
+++ b/lib/Model/CreateCouponCollection.php
@@ -180,7 +180,7 @@ class CreateCouponCollection implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
         $this->container['defaultCoupon'] = isset($data['defaultCoupon']) ? $data['defaultCoupon'] : null;
@@ -337,5 +337,3 @@ class CreateCouponCollection implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/CreateCoupons.php
+++ b/lib/Model/CreateCoupons.php
@@ -180,7 +180,7 @@ class CreateCoupons implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['collectionId'] = isset($data['collectionId']) ? $data['collectionId'] : null;
         $this->container['coupons'] = isset($data['coupons']) ? $data['coupons'] : null;
@@ -337,5 +337,3 @@ class CreateCoupons implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/CreateDoiContact.php
+++ b/lib/Model/CreateDoiContact.php
@@ -200,7 +200,7 @@ class CreateDoiContact implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['email'] = isset($data['email']) ? $data['email'] : null;
         $this->container['attributes'] = isset($data['attributes']) ? $data['attributes'] : null;
@@ -463,5 +463,3 @@ class CreateDoiContact implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/CreateDomain.php
+++ b/lib/Model/CreateDomain.php
@@ -175,7 +175,7 @@ class CreateDomain implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
     }
@@ -304,5 +304,3 @@ class CreateDomain implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/CreateDomainModel.php
+++ b/lib/Model/CreateDomainModel.php
@@ -190,7 +190,7 @@ class CreateDomainModel implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['domainName'] = isset($data['domainName']) ? $data['domainName'] : null;
@@ -394,5 +394,3 @@ class CreateDomainModel implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/CreateDomainModelDnsRecords.php
+++ b/lib/Model/CreateDomainModelDnsRecords.php
@@ -180,7 +180,7 @@ class CreateDomainModelDnsRecords implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['dkimRecord'] = isset($data['dkimRecord']) ? $data['dkimRecord'] : null;
         $this->container['brevoCode'] = isset($data['brevoCode']) ? $data['brevoCode'] : null;
@@ -331,5 +331,3 @@ class CreateDomainModelDnsRecords implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/CreateDomainModelDnsRecordsDkimRecord.php
+++ b/lib/Model/CreateDomainModelDnsRecordsDkimRecord.php
@@ -190,7 +190,7 @@ class CreateDomainModelDnsRecordsDkimRecord implements ModelInterface, ArrayAcce
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['type'] = isset($data['type']) ? $data['type'] : null;
         $this->container['value'] = isset($data['value']) ? $data['value'] : null;
@@ -391,5 +391,3 @@ class CreateDomainModelDnsRecordsDkimRecord implements ModelInterface, ArrayAcce
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/CreateEmailCampaign.php
+++ b/lib/Model/CreateEmailCampaign.php
@@ -340,7 +340,7 @@ class CreateEmailCampaign implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['tag'] = isset($data['tag']) ? $data['tag'] : null;
         $this->container['sender'] = isset($data['sender']) ? $data['sender'] : null;
@@ -1287,5 +1287,3 @@ class CreateEmailCampaign implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/CreateEmailCampaignRecipients.php
+++ b/lib/Model/CreateEmailCampaignRecipients.php
@@ -186,7 +186,7 @@ class CreateEmailCampaignRecipients implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['exclusionListIds'] = isset($data['exclusionListIds']) ? $data['exclusionListIds'] : null;
         $this->container['listIds'] = isset($data['listIds']) ? $data['listIds'] : null;
@@ -362,5 +362,3 @@ class CreateEmailCampaignRecipients implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/CreateEmailCampaignSender.php
+++ b/lib/Model/CreateEmailCampaignSender.php
@@ -186,7 +186,7 @@ class CreateEmailCampaignSender implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
         $this->container['email'] = isset($data['email']) ? $data['email'] : null;
@@ -365,5 +365,3 @@ class CreateEmailCampaignSender implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/CreateExternalFeed.php
+++ b/lib/Model/CreateExternalFeed.php
@@ -232,7 +232,7 @@ class CreateExternalFeed implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
         $this->container['url'] = isset($data['url']) ? $data['url'] : null;
@@ -597,5 +597,3 @@ class CreateExternalFeed implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/CreateList.php
+++ b/lib/Model/CreateList.php
@@ -177,7 +177,7 @@ class CreateList implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
         $this->container['folderId'] = isset($data['folderId']) ? $data['folderId'] : null;

--- a/lib/Model/CreateModel.php
+++ b/lib/Model/CreateModel.php
@@ -175,7 +175,7 @@ class CreateModel implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
     }
@@ -304,5 +304,3 @@ class CreateModel implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/CreateProductModel.php
+++ b/lib/Model/CreateProductModel.php
@@ -175,7 +175,7 @@ class CreateProductModel implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
     }
@@ -301,5 +301,3 @@ class CreateProductModel implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/CreateReseller.php
+++ b/lib/Model/CreateReseller.php
@@ -180,7 +180,7 @@ class CreateReseller implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['authKey'] = isset($data['authKey']) ? $data['authKey'] : null;
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
@@ -334,5 +334,3 @@ class CreateReseller implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/CreateSender.php
+++ b/lib/Model/CreateSender.php
@@ -185,7 +185,7 @@ class CreateSender implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
         $this->container['email'] = isset($data['email']) ? $data['email'] : null;
@@ -367,5 +367,3 @@ class CreateSender implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/CreateSenderIps.php
+++ b/lib/Model/CreateSenderIps.php
@@ -185,7 +185,7 @@ class CreateSenderIps implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['ip'] = isset($data['ip']) ? $data['ip'] : null;
         $this->container['domain'] = isset($data['domain']) ? $data['domain'] : null;
@@ -383,5 +383,3 @@ class CreateSenderIps implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/CreateSenderModel.php
+++ b/lib/Model/CreateSenderModel.php
@@ -185,7 +185,7 @@ class CreateSenderModel implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['spfError'] = isset($data['spfError']) ? $data['spfError'] : null;
@@ -364,5 +364,3 @@ class CreateSenderModel implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/CreateSmsCampaign.php
+++ b/lib/Model/CreateSmsCampaign.php
@@ -210,7 +210,7 @@ class CreateSmsCampaign implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
         $this->container['sender'] = isset($data['sender']) ? $data['sender'] : null;
@@ -528,5 +528,3 @@ class CreateSmsCampaign implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/CreateSmsCampaignRecipients.php
+++ b/lib/Model/CreateSmsCampaignRecipients.php
@@ -180,7 +180,7 @@ class CreateSmsCampaignRecipients implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['listIds'] = isset($data['listIds']) ? $data['listIds'] : null;
         $this->container['exclusionListIds'] = isset($data['exclusionListIds']) ? $data['exclusionListIds'] : null;
@@ -334,5 +334,3 @@ class CreateSmsCampaignRecipients implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/CreateSmtpEmail.php
+++ b/lib/Model/CreateSmtpEmail.php
@@ -180,7 +180,7 @@ class CreateSmtpEmail implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['messageId'] = isset($data['messageId']) ? $data['messageId'] : null;
         $this->container['messageIds'] = isset($data['messageIds']) ? $data['messageIds'] : null;
@@ -331,5 +331,3 @@ class CreateSmtpEmail implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/CreateSmtpTemplate.php
+++ b/lib/Model/CreateSmtpTemplate.php
@@ -220,7 +220,7 @@ class CreateSmtpTemplate implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['tag'] = isset($data['tag']) ? $data['tag'] : null;
         $this->container['sender'] = isset($data['sender']) ? $data['sender'] : null;
@@ -580,5 +580,3 @@ class CreateSmtpTemplate implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/CreateSmtpTemplateSender.php
+++ b/lib/Model/CreateSmtpTemplateSender.php
@@ -186,7 +186,7 @@ class CreateSmtpTemplateSender implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
         $this->container['email'] = isset($data['email']) ? $data['email'] : null;
@@ -362,5 +362,3 @@ class CreateSmtpTemplateSender implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/CreateSubAccount.php
+++ b/lib/Model/CreateSubAccount.php
@@ -213,7 +213,7 @@ class CreateSubAccount implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['companyName'] = isset($data['companyName']) ? $data['companyName'] : null;
         $this->container['email'] = isset($data['email']) ? $data['email'] : null;
@@ -437,5 +437,3 @@ class CreateSubAccount implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/CreateSubAccountResponse.php
+++ b/lib/Model/CreateSubAccountResponse.php
@@ -175,7 +175,7 @@ class CreateSubAccountResponse implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
     }
@@ -304,5 +304,3 @@ class CreateSubAccountResponse implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/CreateUpdateBatchCategory.php
+++ b/lib/Model/CreateUpdateBatchCategory.php
@@ -180,7 +180,7 @@ class CreateUpdateBatchCategory implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['categories'] = isset($data['categories']) ? $data['categories'] : null;
         $this->container['updateEnabled'] = isset($data['updateEnabled']) ? $data['updateEnabled'] : null;
@@ -334,5 +334,3 @@ class CreateUpdateBatchCategory implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/CreateUpdateBatchCategoryModel.php
+++ b/lib/Model/CreateUpdateBatchCategoryModel.php
@@ -180,7 +180,7 @@ class CreateUpdateBatchCategoryModel implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['createdCount'] = isset($data['createdCount']) ? $data['createdCount'] : null;
         $this->container['updatedCount'] = isset($data['updatedCount']) ? $data['updatedCount'] : null;
@@ -331,5 +331,3 @@ class CreateUpdateBatchCategoryModel implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/CreateUpdateBatchProducts.php
+++ b/lib/Model/CreateUpdateBatchProducts.php
@@ -180,7 +180,7 @@ class CreateUpdateBatchProducts implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['products'] = isset($data['products']) ? $data['products'] : null;
         $this->container['updateEnabled'] = isset($data['updateEnabled']) ? $data['updateEnabled'] : null;
@@ -334,5 +334,3 @@ class CreateUpdateBatchProducts implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/CreateUpdateBatchProductsModel.php
+++ b/lib/Model/CreateUpdateBatchProductsModel.php
@@ -180,7 +180,7 @@ class CreateUpdateBatchProductsModel implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['createdCount'] = isset($data['createdCount']) ? $data['createdCount'] : null;
         $this->container['updatedCount'] = isset($data['updatedCount']) ? $data['updatedCount'] : null;
@@ -331,5 +331,3 @@ class CreateUpdateBatchProductsModel implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/CreateUpdateCategories.php
+++ b/lib/Model/CreateUpdateCategories.php
@@ -190,7 +190,7 @@ class CreateUpdateCategories implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
@@ -394,5 +394,3 @@ class CreateUpdateCategories implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/CreateUpdateCategory.php
+++ b/lib/Model/CreateUpdateCategory.php
@@ -195,7 +195,7 @@ class CreateUpdateCategory implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
@@ -424,5 +424,3 @@ class CreateUpdateCategory implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/CreateUpdateContactModel.php
+++ b/lib/Model/CreateUpdateContactModel.php
@@ -175,7 +175,7 @@ class CreateUpdateContactModel implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
     }
@@ -301,5 +301,3 @@ class CreateUpdateContactModel implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/CreateUpdateFolder.php
+++ b/lib/Model/CreateUpdateFolder.php
@@ -172,7 +172,7 @@ class CreateUpdateFolder implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
     }

--- a/lib/Model/CreateUpdateProduct.php
+++ b/lib/Model/CreateUpdateProduct.php
@@ -225,7 +225,7 @@ class CreateUpdateProduct implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
@@ -607,5 +607,3 @@ class CreateUpdateProduct implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/CreateUpdateProducts.php
+++ b/lib/Model/CreateUpdateProducts.php
@@ -220,7 +220,7 @@ class CreateUpdateProducts implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
@@ -577,5 +577,3 @@ class CreateUpdateProducts implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/CreateWebhook.php
+++ b/lib/Model/CreateWebhook.php
@@ -272,7 +272,7 @@ class CreateWebhook implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['url'] = isset($data['url']) ? $data['url'] : null;
         $this->container['description'] = isset($data['description']) ? $data['description'] : null;
@@ -605,5 +605,3 @@ class CreateWebhook implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/CreateWhatsAppCampaign.php
+++ b/lib/Model/CreateWhatsAppCampaign.php
@@ -190,7 +190,7 @@ class CreateWhatsAppCampaign implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
         $this->container['templateId'] = isset($data['templateId']) ? $data['templateId'] : null;
@@ -403,5 +403,3 @@ class CreateWhatsAppCampaign implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/CreateWhatsAppCampaignRecipients.php
+++ b/lib/Model/CreateWhatsAppCampaignRecipients.php
@@ -186,7 +186,7 @@ class CreateWhatsAppCampaignRecipients implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['excludedListIds'] = isset($data['excludedListIds']) ? $data['excludedListIds'] : null;
         $this->container['listIds'] = isset($data['listIds']) ? $data['listIds'] : null;
@@ -362,5 +362,3 @@ class CreateWhatsAppCampaignRecipients implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/CreateWhatsAppTemplate.php
+++ b/lib/Model/CreateWhatsAppTemplate.php
@@ -235,7 +235,7 @@ class CreateWhatsAppTemplate implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
         $this->container['language'] = isset($data['language']) ? $data['language'] : null;
@@ -557,5 +557,3 @@ class CreateWhatsAppTemplate implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/CreatedBatchId.php
+++ b/lib/Model/CreatedBatchId.php
@@ -175,7 +175,7 @@ class CreatedBatchId implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['batchId'] = isset($data['batchId']) ? $data['batchId'] : null;
     }
@@ -304,5 +304,3 @@ class CreatedBatchId implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/CreatedProcessId.php
+++ b/lib/Model/CreatedProcessId.php
@@ -175,7 +175,7 @@ class CreatedProcessId implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['processId'] = isset($data['processId']) ? $data['processId'] : null;
     }
@@ -304,5 +304,3 @@ class CreatedProcessId implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/Deal.php
+++ b/lib/Model/Deal.php
@@ -191,7 +191,7 @@ class Deal implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['attributes'] = isset($data['attributes']) ? $data['attributes'] : null;
@@ -392,5 +392,3 @@ class Deal implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/DealAttributes.php
+++ b/lib/Model/DealAttributes.php
@@ -176,7 +176,7 @@ class DealAttributes implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
     }
 
@@ -277,5 +277,3 @@ class DealAttributes implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/DealAttributesInner.php
+++ b/lib/Model/DealAttributesInner.php
@@ -196,7 +196,7 @@ class DealAttributesInner implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['internalName'] = isset($data['internalName']) ? $data['internalName'] : null;
         $this->container['label'] = isset($data['label']) ? $data['label'] : null;
@@ -422,5 +422,3 @@ class DealAttributesInner implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/DealsList.php
+++ b/lib/Model/DealsList.php
@@ -176,7 +176,7 @@ class DealsList implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['items'] = isset($data['items']) ? $data['items'] : null;
     }
@@ -302,5 +302,3 @@ class DealsList implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/DeleteHardbounces.php
+++ b/lib/Model/DeleteHardbounces.php
@@ -185,7 +185,7 @@ class DeleteHardbounces implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['startDate'] = isset($data['startDate']) ? $data['startDate'] : null;
         $this->container['endDate'] = isset($data['endDate']) ? $data['endDate'] : null;
@@ -361,5 +361,3 @@ class DeleteHardbounces implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/EmailExportRecipients.php
+++ b/lib/Model/EmailExportRecipients.php
@@ -207,7 +207,7 @@ class EmailExportRecipients implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['notifyURL'] = isset($data['notifyURL']) ? $data['notifyURL'] : null;
         $this->container['recipientsType'] = isset($data['recipientsType']) ? $data['recipientsType'] : null;
@@ -378,5 +378,3 @@ class EmailExportRecipients implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/Event.php
+++ b/lib/Model/Event.php
@@ -195,7 +195,7 @@ class Event implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['eventName'] = isset($data['eventName']) ? $data['eventName'] : null;
         $this->container['eventDate'] = isset($data['eventDate']) ? $data['eventDate'] : null;
@@ -427,5 +427,3 @@ class Event implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/EventIdentifiers.php
+++ b/lib/Model/EventIdentifiers.php
@@ -196,7 +196,7 @@ class EventIdentifiers implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['emailId'] = isset($data['emailId']) ? $data['emailId'] : null;
         $this->container['phoneId'] = isset($data['phoneId']) ? $data['phoneId'] : null;
@@ -422,5 +422,3 @@ class EventIdentifiers implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/ExportWebhooksHistory.php
+++ b/lib/Model/ExportWebhooksHistory.php
@@ -280,7 +280,7 @@ class ExportWebhooksHistory implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['days'] = isset($data['days']) ? $data['days'] : null;
         $this->container['startDate'] = isset($data['startDate']) ? $data['startDate'] : null;
@@ -674,5 +674,3 @@ class ExportWebhooksHistory implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/FileData.php
+++ b/lib/Model/FileData.php
@@ -226,7 +226,7 @@ class FileData implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['url'] = isset($data['url']) ? $data['url'] : null;
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
@@ -578,5 +578,3 @@ class FileData implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/FileDownloadableLink.php
+++ b/lib/Model/FileDownloadableLink.php
@@ -175,7 +175,7 @@ class FileDownloadableLink implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['fileUrl'] = isset($data['fileUrl']) ? $data['fileUrl'] : null;
     }
@@ -304,5 +304,3 @@ class FileDownloadableLink implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/FileList.php
+++ b/lib/Model/FileList.php
@@ -176,7 +176,7 @@ class FileList implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
     }
 
@@ -277,5 +277,3 @@ class FileList implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetAccount.php
+++ b/lib/Model/GetAccount.php
@@ -177,7 +177,7 @@ class GetAccount extends GetExtendedClient
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         parent::__construct($data);
 
@@ -361,5 +361,3 @@ class GetAccount extends GetExtendedClient
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetAccountActivity.php
+++ b/lib/Model/GetAccountActivity.php
@@ -175,7 +175,7 @@ class GetAccountActivity implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['logs'] = isset($data['logs']) ? $data['logs'] : null;
     }
@@ -301,5 +301,3 @@ class GetAccountActivity implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetAccountActivityLogs.php
+++ b/lib/Model/GetAccountActivityLogs.php
@@ -195,7 +195,7 @@ class GetAccountActivityLogs implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['action'] = isset($data['action']) ? $data['action'] : null;
         $this->container['date'] = isset($data['date']) ? $data['date'] : null;
@@ -436,5 +436,3 @@ class GetAccountActivityLogs implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetAccountMarketingAutomation.php
+++ b/lib/Model/GetAccountMarketingAutomation.php
@@ -180,7 +180,7 @@ class GetAccountMarketingAutomation implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['key'] = isset($data['key']) ? $data['key'] : null;
         $this->container['enabled'] = isset($data['enabled']) ? $data['enabled'] : null;
@@ -334,5 +334,3 @@ class GetAccountMarketingAutomation implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetAccountPlan.php
+++ b/lib/Model/GetAccountPlan.php
@@ -234,7 +234,7 @@ class GetAccountPlan implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['type'] = isset($data['type']) ? $data['type'] : null;
         $this->container['creditsType'] = isset($data['creditsType']) ? $data['creditsType'] : null;
@@ -528,5 +528,3 @@ class GetAccountPlan implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetAccountRelay.php
+++ b/lib/Model/GetAccountRelay.php
@@ -181,7 +181,7 @@ class GetAccountRelay implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['enabled'] = isset($data['enabled']) ? $data['enabled'] : null;
         $this->container['data'] = isset($data['data']) ? $data['data'] : null;
@@ -338,5 +338,3 @@ class GetAccountRelay implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetAccountRelayData.php
+++ b/lib/Model/GetAccountRelayData.php
@@ -186,7 +186,7 @@ class GetAccountRelayData implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['userName'] = isset($data['userName']) ? $data['userName'] : null;
         $this->container['relay'] = isset($data['relay']) ? $data['relay'] : null;
@@ -371,5 +371,3 @@ class GetAccountRelayData implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetAggregatedReport.php
+++ b/lib/Model/GetAggregatedReport.php
@@ -235,7 +235,7 @@ class GetAggregatedReport implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['range'] = isset($data['range']) ? $data['range'] : null;
         $this->container['requests'] = isset($data['requests']) ? $data['requests'] : null;
@@ -661,5 +661,3 @@ class GetAggregatedReport implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetAllExternalFeeds.php
+++ b/lib/Model/GetAllExternalFeeds.php
@@ -180,7 +180,7 @@ class GetAllExternalFeeds implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['count'] = isset($data['count']) ? $data['count'] : null;
         $this->container['feeds'] = isset($data['feeds']) ? $data['feeds'] : null;
@@ -331,5 +331,3 @@ class GetAllExternalFeeds implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetAllExternalFeedsFeeds.php
+++ b/lib/Model/GetAllExternalFeedsFeeds.php
@@ -247,7 +247,7 @@ class GetAllExternalFeedsFeeds implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
@@ -708,5 +708,3 @@ class GetAllExternalFeedsFeeds implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetAttributes.php
+++ b/lib/Model/GetAttributes.php
@@ -172,7 +172,7 @@ class GetAttributes implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['attributes'] = isset($data['attributes']) ? $data['attributes'] : null;
     }

--- a/lib/Model/GetAttributesAttributes.php
+++ b/lib/Model/GetAttributesAttributes.php
@@ -237,7 +237,7 @@ class GetAttributesAttributes implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
         $this->container['category'] = isset($data['category']) ? $data['category'] : null;
@@ -503,5 +503,3 @@ class GetAttributesAttributes implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetAttributesEnumeration.php
+++ b/lib/Model/GetAttributesEnumeration.php
@@ -180,7 +180,7 @@ class GetAttributesEnumeration implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['value'] = isset($data['value']) ? $data['value'] : null;
         $this->container['label'] = isset($data['label']) ? $data['label'] : null;
@@ -337,5 +337,3 @@ class GetAttributesEnumeration implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetBlockedDomains.php
+++ b/lib/Model/GetBlockedDomains.php
@@ -176,7 +176,7 @@ class GetBlockedDomains implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['domains'] = isset($data['domains']) ? $data['domains'] : null;
     }
@@ -305,5 +305,3 @@ class GetBlockedDomains implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetCampaignRecipients.php
+++ b/lib/Model/GetCampaignRecipients.php
@@ -180,7 +180,7 @@ class GetCampaignRecipients implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['lists'] = isset($data['lists']) ? $data['lists'] : null;
         $this->container['exclusionLists'] = isset($data['exclusionLists']) ? $data['exclusionLists'] : null;
@@ -337,5 +337,3 @@ class GetCampaignRecipients implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetCampaignStats.php
+++ b/lib/Model/GetCampaignStats.php
@@ -252,7 +252,7 @@ class GetCampaignStats implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['listId'] = isset($data['listId']) ? $data['listId'] : null;
         $this->container['uniqueClicks'] = isset($data['uniqueClicks']) ? $data['uniqueClicks'] : null;

--- a/lib/Model/GetCategories.php
+++ b/lib/Model/GetCategories.php
@@ -180,7 +180,7 @@ class GetCategories implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['categories'] = isset($data['categories']) ? $data['categories'] : null;
         $this->container['count'] = isset($data['count']) ? $data['count'] : null;
@@ -337,5 +337,3 @@ class GetCategories implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetCategoryDetails.php
+++ b/lib/Model/GetCategoryDetails.php
@@ -200,7 +200,7 @@ class GetCategoryDetails implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
@@ -463,5 +463,3 @@ class GetCategoryDetails implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetChildAccountCreationStatus.php
+++ b/lib/Model/GetChildAccountCreationStatus.php
@@ -175,7 +175,7 @@ class GetChildAccountCreationStatus implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['childAccountCreated'] = isset($data['childAccountCreated']) ? $data['childAccountCreated'] : null;
     }
@@ -304,5 +304,3 @@ class GetChildAccountCreationStatus implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetChildDomain.php
+++ b/lib/Model/GetChildDomain.php
@@ -180,7 +180,7 @@ class GetChildDomain implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['domain'] = isset($data['domain']) ? $data['domain'] : null;
         $this->container['active'] = isset($data['active']) ? $data['active'] : null;
@@ -331,5 +331,3 @@ class GetChildDomain implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetChildDomains.php
+++ b/lib/Model/GetChildDomains.php
@@ -175,7 +175,7 @@ class GetChildDomains implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
     }
 
@@ -276,5 +276,3 @@ class GetChildDomains implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetChildInfo.php
+++ b/lib/Model/GetChildInfo.php
@@ -187,7 +187,7 @@ class GetChildInfo extends GetClient
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         parent::__construct($data);
 
@@ -418,5 +418,3 @@ class GetChildInfo extends GetClient
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetChildInfoApiKeys.php
+++ b/lib/Model/GetChildInfoApiKeys.php
@@ -181,7 +181,7 @@ class GetChildInfoApiKeys implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['v2'] = isset($data['v2']) ? $data['v2'] : null;
         $this->container['v3'] = isset($data['v3']) ? $data['v3'] : null;
@@ -335,5 +335,3 @@ class GetChildInfoApiKeys implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetChildInfoApiKeysV2.php
+++ b/lib/Model/GetChildInfoApiKeysV2.php
@@ -180,7 +180,7 @@ class GetChildInfoApiKeysV2 implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
         $this->container['key'] = isset($data['key']) ? $data['key'] : null;
@@ -337,5 +337,3 @@ class GetChildInfoApiKeysV2 implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetChildInfoApiKeysV3.php
+++ b/lib/Model/GetChildInfoApiKeysV3.php
@@ -180,7 +180,7 @@ class GetChildInfoApiKeysV3 implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
         $this->container['key'] = isset($data['key']) ? $data['key'] : null;
@@ -337,5 +337,3 @@ class GetChildInfoApiKeysV3 implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetChildInfoCredits.php
+++ b/lib/Model/GetChildInfoCredits.php
@@ -181,7 +181,7 @@ class GetChildInfoCredits implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['emailCredits'] = isset($data['emailCredits']) ? $data['emailCredits'] : null;
         $this->container['smsCredits'] = isset($data['smsCredits']) ? $data['smsCredits'] : null;
@@ -332,5 +332,3 @@ class GetChildInfoCredits implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetChildInfoStatistics.php
+++ b/lib/Model/GetChildInfoStatistics.php
@@ -186,7 +186,7 @@ class GetChildInfoStatistics implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['previousMonthTotalSent'] = isset($data['previousMonthTotalSent']) ? $data['previousMonthTotalSent'] : null;
         $this->container['currentMonthTotalSent'] = isset($data['currentMonthTotalSent']) ? $data['currentMonthTotalSent'] : null;
@@ -362,5 +362,3 @@ class GetChildInfoStatistics implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetChildrenList.php
+++ b/lib/Model/GetChildrenList.php
@@ -180,7 +180,7 @@ class GetChildrenList implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['children'] = isset($data['children']) ? $data['children'] : null;
         $this->container['count'] = isset($data['count']) ? $data['count'] : null;
@@ -331,5 +331,3 @@ class GetChildrenList implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetClient.php
+++ b/lib/Model/GetClient.php
@@ -190,7 +190,7 @@ class GetClient implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['email'] = isset($data['email']) ? $data['email'] : null;
         $this->container['firstName'] = isset($data['firstName']) ? $data['firstName'] : null;
@@ -403,5 +403,3 @@ class GetClient implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetContactCampaignStats.php
+++ b/lib/Model/GetContactCampaignStats.php
@@ -216,7 +216,7 @@ class GetContactCampaignStats implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['messagesSent'] = isset($data['messagesSent']) ? $data['messagesSent'] : null;
         $this->container['hardBounces'] = isset($data['hardBounces']) ? $data['hardBounces'] : null;
@@ -542,5 +542,3 @@ class GetContactCampaignStats implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetContactCampaignStatsClicked.php
+++ b/lib/Model/GetContactCampaignStatsClicked.php
@@ -180,7 +180,7 @@ class GetContactCampaignStatsClicked implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['campaignId'] = isset($data['campaignId']) ? $data['campaignId'] : null;
         $this->container['links'] = isset($data['links']) ? $data['links'] : null;
@@ -337,5 +337,3 @@ class GetContactCampaignStatsClicked implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetContactCampaignStatsOpened.php
+++ b/lib/Model/GetContactCampaignStatsOpened.php
@@ -190,7 +190,7 @@ class GetContactCampaignStatsOpened implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['campaignId'] = isset($data['campaignId']) ? $data['campaignId'] : null;
         $this->container['count'] = isset($data['count']) ? $data['count'] : null;
@@ -403,5 +403,3 @@ class GetContactCampaignStatsOpened implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetContactCampaignStatsTransacAttributes.php
+++ b/lib/Model/GetContactCampaignStatsTransacAttributes.php
@@ -185,7 +185,7 @@ class GetContactCampaignStatsTransacAttributes implements ModelInterface, ArrayA
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['orderDate'] = isset($data['orderDate']) ? $data['orderDate'] : null;
         $this->container['orderPrice'] = isset($data['orderPrice']) ? $data['orderPrice'] : null;
@@ -370,5 +370,3 @@ class GetContactCampaignStatsTransacAttributes implements ModelInterface, ArrayA
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetContactCampaignStatsUnsubscriptions.php
+++ b/lib/Model/GetContactCampaignStatsUnsubscriptions.php
@@ -180,7 +180,7 @@ class GetContactCampaignStatsUnsubscriptions implements ModelInterface, ArrayAcc
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['userUnsubscription'] = isset($data['userUnsubscription']) ? $data['userUnsubscription'] : null;
         $this->container['adminUnsubscription'] = isset($data['adminUnsubscription']) ? $data['adminUnsubscription'] : null;
@@ -337,5 +337,3 @@ class GetContactCampaignStatsUnsubscriptions implements ModelInterface, ArrayAcc
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetContactDetails.php
+++ b/lib/Model/GetContactDetails.php
@@ -212,7 +212,7 @@ class GetContactDetails implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['email'] = isset($data['email']) ? $data['email'] : null;
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;

--- a/lib/Model/GetContacts.php
+++ b/lib/Model/GetContacts.php
@@ -177,7 +177,7 @@ class GetContacts implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['contacts'] = isset($data['contacts']) ? $data['contacts'] : null;
         $this->container['count'] = isset($data['count']) ? $data['count'] : null;

--- a/lib/Model/GetCorporateInvitedUsersList.php
+++ b/lib/Model/GetCorporateInvitedUsersList.php
@@ -175,7 +175,7 @@ class GetCorporateInvitedUsersList implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['users'] = isset($data['users']) ? $data['users'] : null;
     }
@@ -301,5 +301,3 @@ class GetCorporateInvitedUsersList implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetCorporateInvitedUsersListFeatureAccess.php
+++ b/lib/Model/GetCorporateInvitedUsersListFeatureAccess.php
@@ -191,7 +191,7 @@ class GetCorporateInvitedUsersListFeatureAccess implements ModelInterface, Array
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['userManagement'] = isset($data['userManagement']) ? $data['userManagement'] : null;
         $this->container['apiKeys'] = isset($data['apiKeys']) ? $data['apiKeys'] : null;
@@ -392,5 +392,3 @@ class GetCorporateInvitedUsersListFeatureAccess implements ModelInterface, Array
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetCorporateInvitedUsersListGroups.php
+++ b/lib/Model/GetCorporateInvitedUsersListGroups.php
@@ -181,7 +181,7 @@ class GetCorporateInvitedUsersListGroups implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
@@ -332,5 +332,3 @@ class GetCorporateInvitedUsersListGroups implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetCorporateInvitedUsersListUsers.php
+++ b/lib/Model/GetCorporateInvitedUsersListUsers.php
@@ -195,7 +195,7 @@ class GetCorporateInvitedUsersListUsers implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['groups'] = isset($data['groups']) ? $data['groups'] : null;
         $this->container['email'] = isset($data['email']) ? $data['email'] : null;
@@ -436,5 +436,3 @@ class GetCorporateInvitedUsersListUsers implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetCouponCollection.php
+++ b/lib/Model/GetCouponCollection.php
@@ -200,7 +200,7 @@ class GetCouponCollection implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
@@ -469,5 +469,3 @@ class GetCouponCollection implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetDeviceBrowserStats.php
+++ b/lib/Model/GetDeviceBrowserStats.php
@@ -190,7 +190,7 @@ class GetDeviceBrowserStats implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['clickers'] = isset($data['clickers']) ? $data['clickers'] : null;
         $this->container['uniqueClicks'] = isset($data['uniqueClicks']) ? $data['uniqueClicks'] : null;
@@ -403,5 +403,3 @@ class GetDeviceBrowserStats implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetDomainConfigurationModel.php
+++ b/lib/Model/GetDomainConfigurationModel.php
@@ -190,7 +190,7 @@ class GetDomainConfigurationModel implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['domain'] = isset($data['domain']) ? $data['domain'] : null;
         $this->container['verified'] = isset($data['verified']) ? $data['verified'] : null;
@@ -403,5 +403,3 @@ class GetDomainConfigurationModel implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetDomainsList.php
+++ b/lib/Model/GetDomainsList.php
@@ -175,7 +175,7 @@ class GetDomainsList implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['domains'] = isset($data['domains']) ? $data['domains'] : null;
     }
@@ -301,5 +301,3 @@ class GetDomainsList implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetDomainsListDomains.php
+++ b/lib/Model/GetDomainsListDomains.php
@@ -195,7 +195,7 @@ class GetDomainsListDomains implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['domainName'] = isset($data['domainName']) ? $data['domainName'] : null;
@@ -433,5 +433,3 @@ class GetDomainsListDomains implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetEmailEventReport.php
+++ b/lib/Model/GetEmailEventReport.php
@@ -175,7 +175,7 @@ class GetEmailEventReport implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['events'] = isset($data['events']) ? $data['events'] : null;
     }
@@ -301,5 +301,3 @@ class GetEmailEventReport implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetEmailEventReportEvents.php
+++ b/lib/Model/GetEmailEventReportEvents.php
@@ -264,7 +264,7 @@ class GetEmailEventReportEvents implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['email'] = isset($data['email']) ? $data['email'] : null;
         $this->container['date'] = isset($data['date']) ? $data['date'] : null;
@@ -669,5 +669,3 @@ class GetEmailEventReportEvents implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetExtendedCampaignStats.php
+++ b/lib/Model/GetExtendedCampaignStats.php
@@ -210,7 +210,7 @@ class GetExtendedCampaignStats implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['globalStats'] = isset($data['globalStats']) ? $data['globalStats'] : null;
         $this->container['campaignStats'] = isset($data['campaignStats']) ? $data['campaignStats'] : null;
@@ -535,5 +535,3 @@ class GetExtendedCampaignStats implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetExtendedCampaignStatsGlobalStats.php
+++ b/lib/Model/GetExtendedCampaignStatsGlobalStats.php
@@ -176,7 +176,7 @@ class GetExtendedCampaignStatsGlobalStats implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
     }
 
@@ -277,5 +277,3 @@ class GetExtendedCampaignStatsGlobalStats implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetExtendedClient.php
+++ b/lib/Model/GetExtendedClient.php
@@ -167,7 +167,7 @@ class GetExtendedClient extends GetClient
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         parent::__construct($data);
 
@@ -298,5 +298,3 @@ class GetExtendedClient extends GetClient
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetExtendedClientAddress.php
+++ b/lib/Model/GetExtendedClientAddress.php
@@ -191,7 +191,7 @@ class GetExtendedClientAddress implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['street'] = isset($data['street']) ? $data['street'] : null;
         $this->container['city'] = isset($data['city']) ? $data['city'] : null;
@@ -404,5 +404,3 @@ class GetExtendedClientAddress implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetExtendedContactDetails.php
+++ b/lib/Model/GetExtendedContactDetails.php
@@ -221,7 +221,7 @@ class GetExtendedContactDetails implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['email'] = isset($data['email']) ? $data['email'] : null;
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
@@ -599,5 +599,3 @@ class GetExtendedContactDetails implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetExtendedContactDetailsStatistics.php
+++ b/lib/Model/GetExtendedContactDetailsStatistics.php
@@ -216,7 +216,7 @@ class GetExtendedContactDetailsStatistics implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['messagesSent'] = isset($data['messagesSent']) ? $data['messagesSent'] : null;
         $this->container['hardBounces'] = isset($data['hardBounces']) ? $data['hardBounces'] : null;
@@ -542,5 +542,3 @@ class GetExtendedContactDetailsStatistics implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetExtendedContactDetailsStatisticsClicked.php
+++ b/lib/Model/GetExtendedContactDetailsStatisticsClicked.php
@@ -180,7 +180,7 @@ class GetExtendedContactDetailsStatisticsClicked implements ModelInterface, Arra
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['campaignId'] = isset($data['campaignId']) ? $data['campaignId'] : null;
         $this->container['links'] = isset($data['links']) ? $data['links'] : null;
@@ -337,5 +337,3 @@ class GetExtendedContactDetailsStatisticsClicked implements ModelInterface, Arra
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetExtendedContactDetailsStatisticsDelivered.php
+++ b/lib/Model/GetExtendedContactDetailsStatisticsDelivered.php
@@ -180,7 +180,7 @@ class GetExtendedContactDetailsStatisticsDelivered implements ModelInterface, Ar
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['campaignId'] = isset($data['campaignId']) ? $data['campaignId'] : null;
         $this->container['eventTime'] = isset($data['eventTime']) ? $data['eventTime'] : null;
@@ -333,5 +333,3 @@ class GetExtendedContactDetailsStatisticsDelivered implements ModelInterface, Ar
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetExtendedContactDetailsStatisticsLinks.php
+++ b/lib/Model/GetExtendedContactDetailsStatisticsLinks.php
@@ -190,7 +190,7 @@ class GetExtendedContactDetailsStatisticsLinks implements ModelInterface, ArrayA
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['count'] = isset($data['count']) ? $data['count'] : null;
         $this->container['eventTime'] = isset($data['eventTime']) ? $data['eventTime'] : null;
@@ -403,5 +403,3 @@ class GetExtendedContactDetailsStatisticsLinks implements ModelInterface, ArrayA
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetExtendedContactDetailsStatisticsMessagesSent.php
+++ b/lib/Model/GetExtendedContactDetailsStatisticsMessagesSent.php
@@ -180,7 +180,7 @@ class GetExtendedContactDetailsStatisticsMessagesSent implements ModelInterface,
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['campaignId'] = isset($data['campaignId']) ? $data['campaignId'] : null;
         $this->container['eventTime'] = isset($data['eventTime']) ? $data['eventTime'] : null;
@@ -337,5 +337,3 @@ class GetExtendedContactDetailsStatisticsMessagesSent implements ModelInterface,
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetExtendedContactDetailsStatisticsOpened.php
+++ b/lib/Model/GetExtendedContactDetailsStatisticsOpened.php
@@ -190,7 +190,7 @@ class GetExtendedContactDetailsStatisticsOpened implements ModelInterface, Array
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['campaignId'] = isset($data['campaignId']) ? $data['campaignId'] : null;
         $this->container['count'] = isset($data['count']) ? $data['count'] : null;
@@ -403,5 +403,3 @@ class GetExtendedContactDetailsStatisticsOpened implements ModelInterface, Array
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetExtendedContactDetailsStatisticsUnsubscriptions.php
+++ b/lib/Model/GetExtendedContactDetailsStatisticsUnsubscriptions.php
@@ -181,7 +181,7 @@ class GetExtendedContactDetailsStatisticsUnsubscriptions implements ModelInterfa
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['userUnsubscription'] = isset($data['userUnsubscription']) ? $data['userUnsubscription'] : null;
         $this->container['adminUnsubscription'] = isset($data['adminUnsubscription']) ? $data['adminUnsubscription'] : null;
@@ -338,5 +338,3 @@ class GetExtendedContactDetailsStatisticsUnsubscriptions implements ModelInterfa
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetExtendedContactDetailsStatisticsUnsubscriptionsAdminUnsubscription.php
+++ b/lib/Model/GetExtendedContactDetailsStatisticsUnsubscriptionsAdminUnsubscription.php
@@ -180,7 +180,7 @@ class GetExtendedContactDetailsStatisticsUnsubscriptionsAdminUnsubscription impl
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['eventTime'] = isset($data['eventTime']) ? $data['eventTime'] : null;
         $this->container['ip'] = isset($data['ip']) ? $data['ip'] : null;
@@ -334,5 +334,3 @@ class GetExtendedContactDetailsStatisticsUnsubscriptionsAdminUnsubscription impl
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetExtendedContactDetailsStatisticsUnsubscriptionsUserUnsubscription.php
+++ b/lib/Model/GetExtendedContactDetailsStatisticsUnsubscriptionsUserUnsubscription.php
@@ -185,7 +185,7 @@ class GetExtendedContactDetailsStatisticsUnsubscriptionsUserUnsubscription imple
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['campaignId'] = isset($data['campaignId']) ? $data['campaignId'] : null;
         $this->container['eventTime'] = isset($data['eventTime']) ? $data['eventTime'] : null;
@@ -367,5 +367,3 @@ class GetExtendedContactDetailsStatisticsUnsubscriptionsUserUnsubscription imple
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetExtendedList.php
+++ b/lib/Model/GetExtendedList.php
@@ -182,7 +182,7 @@ class GetExtendedList extends GetList
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         parent::__construct($data);
 
@@ -391,5 +391,3 @@ class GetExtendedList extends GetList
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetExtendedListCampaignStats.php
+++ b/lib/Model/GetExtendedListCampaignStats.php
@@ -180,7 +180,7 @@ class GetExtendedListCampaignStats implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['campaignId'] = isset($data['campaignId']) ? $data['campaignId'] : null;
         $this->container['stats'] = isset($data['stats']) ? $data['stats'] : null;
@@ -337,5 +337,3 @@ class GetExtendedListCampaignStats implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetExternalFeedByUUID.php
+++ b/lib/Model/GetExternalFeedByUUID.php
@@ -247,7 +247,7 @@ class GetExternalFeedByUUID implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
@@ -708,5 +708,3 @@ class GetExternalFeedByUUID implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetExternalFeedByUUIDHeaders.php
+++ b/lib/Model/GetExternalFeedByUUIDHeaders.php
@@ -180,7 +180,7 @@ class GetExternalFeedByUUIDHeaders implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
         $this->container['value'] = isset($data['value']) ? $data['value'] : null;
@@ -331,5 +331,3 @@ class GetExternalFeedByUUIDHeaders implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetFolder.php
+++ b/lib/Model/GetFolder.php
@@ -195,7 +195,7 @@ class GetFolder implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
@@ -436,5 +436,3 @@ class GetFolder implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetFolderLists.php
+++ b/lib/Model/GetFolderLists.php
@@ -180,7 +180,7 @@ class GetFolderLists implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['lists'] = isset($data['lists']) ? $data['lists'] : null;
         $this->container['count'] = isset($data['count']) ? $data['count'] : null;
@@ -331,5 +331,3 @@ class GetFolderLists implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetFolders.php
+++ b/lib/Model/GetFolders.php
@@ -180,7 +180,7 @@ class GetFolders implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['folders'] = isset($data['folders']) ? $data['folders'] : null;
         $this->container['count'] = isset($data['count']) ? $data['count'] : null;
@@ -331,5 +331,3 @@ class GetFolders implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetInboundEmailEvents.php
+++ b/lib/Model/GetInboundEmailEvents.php
@@ -175,7 +175,7 @@ class GetInboundEmailEvents implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['events'] = isset($data['events']) ? $data['events'] : null;
     }
@@ -301,5 +301,3 @@ class GetInboundEmailEvents implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetInboundEmailEventsByUuid.php
+++ b/lib/Model/GetInboundEmailEventsByUuid.php
@@ -210,7 +210,7 @@ class GetInboundEmailEventsByUuid implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['receivedAt'] = isset($data['receivedAt']) ? $data['receivedAt'] : null;
         $this->container['deliveredAt'] = isset($data['deliveredAt']) ? $data['deliveredAt'] : null;
@@ -511,5 +511,3 @@ class GetInboundEmailEventsByUuid implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetInboundEmailEventsByUuidAttachments.php
+++ b/lib/Model/GetInboundEmailEventsByUuidAttachments.php
@@ -190,7 +190,7 @@ class GetInboundEmailEventsByUuidAttachments implements ModelInterface, ArrayAcc
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
         $this->container['contentType'] = isset($data['contentType']) ? $data['contentType'] : null;
@@ -391,5 +391,3 @@ class GetInboundEmailEventsByUuidAttachments implements ModelInterface, ArrayAcc
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetInboundEmailEventsByUuidLogs.php
+++ b/lib/Model/GetInboundEmailEventsByUuidLogs.php
@@ -199,7 +199,7 @@ class GetInboundEmailEventsByUuidLogs implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['date'] = isset($data['date']) ? $data['date'] : null;
         $this->container['type'] = isset($data['type']) ? $data['type'] : null;
@@ -367,5 +367,3 @@ class GetInboundEmailEventsByUuidLogs implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetInboundEmailEventsEvents.php
+++ b/lib/Model/GetInboundEmailEventsEvents.php
@@ -190,7 +190,7 @@ class GetInboundEmailEventsEvents implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['uuid'] = isset($data['uuid']) ? $data['uuid'] : null;
         $this->container['date'] = isset($data['date']) ? $data['date'] : null;
@@ -403,5 +403,3 @@ class GetInboundEmailEventsEvents implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetInvitedUsersList.php
+++ b/lib/Model/GetInvitedUsersList.php
@@ -175,7 +175,7 @@ class GetInvitedUsersList implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['users'] = isset($data['users']) ? $data['users'] : null;
     }
@@ -301,5 +301,3 @@ class GetInvitedUsersList implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetInvitedUsersListFeatureAccess.php
+++ b/lib/Model/GetInvitedUsersListFeatureAccess.php
@@ -186,7 +186,7 @@ class GetInvitedUsersListFeatureAccess implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['marketing'] = isset($data['marketing']) ? $data['marketing'] : null;
         $this->container['conversations'] = isset($data['conversations']) ? $data['conversations'] : null;
@@ -362,5 +362,3 @@ class GetInvitedUsersListFeatureAccess implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetInvitedUsersListUsers.php
+++ b/lib/Model/GetInvitedUsersListUsers.php
@@ -190,7 +190,7 @@ class GetInvitedUsersListUsers implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['email'] = isset($data['email']) ? $data['email'] : null;
         $this->container['isOwner'] = isset($data['isOwner']) ? $data['isOwner'] : null;
@@ -403,5 +403,3 @@ class GetInvitedUsersListUsers implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetIp.php
+++ b/lib/Model/GetIp.php
@@ -190,7 +190,7 @@ class GetIp implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['ip'] = isset($data['ip']) ? $data['ip'] : null;
@@ -403,5 +403,3 @@ class GetIp implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetIpFromSender.php
+++ b/lib/Model/GetIpFromSender.php
@@ -190,7 +190,7 @@ class GetIpFromSender implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['ip'] = isset($data['ip']) ? $data['ip'] : null;
@@ -403,5 +403,3 @@ class GetIpFromSender implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetIps.php
+++ b/lib/Model/GetIps.php
@@ -175,7 +175,7 @@ class GetIps implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['ips'] = isset($data['ips']) ? $data['ips'] : null;
     }
@@ -304,5 +304,3 @@ class GetIps implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetIpsFromSender.php
+++ b/lib/Model/GetIpsFromSender.php
@@ -175,7 +175,7 @@ class GetIpsFromSender implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['ips'] = isset($data['ips']) ? $data['ips'] : null;
     }
@@ -304,5 +304,3 @@ class GetIpsFromSender implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetList.php
+++ b/lib/Model/GetList.php
@@ -195,7 +195,7 @@ class GetList implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
@@ -436,5 +436,3 @@ class GetList implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetLists.php
+++ b/lib/Model/GetLists.php
@@ -180,7 +180,7 @@ class GetLists implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['lists'] = isset($data['lists']) ? $data['lists'] : null;
         $this->container['count'] = isset($data['count']) ? $data['count'] : null;
@@ -331,5 +331,3 @@ class GetLists implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetOrders.php
+++ b/lib/Model/GetOrders.php
@@ -180,7 +180,7 @@ class GetOrders implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['orders'] = isset($data['orders']) ? $data['orders'] : null;
         $this->container['count'] = isset($data['count']) ? $data['count'] : null;
@@ -331,5 +331,3 @@ class GetOrders implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetProcess.php
+++ b/lib/Model/GetProcess.php
@@ -207,7 +207,7 @@ class GetProcess implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['status'] = isset($data['status']) ? $data['status'] : null;
@@ -434,5 +434,3 @@ class GetProcess implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetProcesses.php
+++ b/lib/Model/GetProcesses.php
@@ -180,7 +180,7 @@ class GetProcesses implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['processes'] = isset($data['processes']) ? $data['processes'] : null;
         $this->container['count'] = isset($data['count']) ? $data['count'] : null;
@@ -331,5 +331,3 @@ class GetProcesses implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetProductDetails.php
+++ b/lib/Model/GetProductDetails.php
@@ -245,7 +245,7 @@ class GetProductDetails implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
@@ -739,5 +739,3 @@ class GetProductDetails implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetProducts.php
+++ b/lib/Model/GetProducts.php
@@ -180,7 +180,7 @@ class GetProducts implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['products'] = isset($data['products']) ? $data['products'] : null;
         $this->container['count'] = isset($data['count']) ? $data['count'] : null;
@@ -337,5 +337,3 @@ class GetProducts implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetReports.php
+++ b/lib/Model/GetReports.php
@@ -175,7 +175,7 @@ class GetReports implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['reports'] = isset($data['reports']) ? $data['reports'] : null;
     }
@@ -301,5 +301,3 @@ class GetReports implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetReportsReports.php
+++ b/lib/Model/GetReportsReports.php
@@ -235,7 +235,7 @@ class GetReportsReports implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['date'] = isset($data['date']) ? $data['date'] : null;
         $this->container['requests'] = isset($data['requests']) ? $data['requests'] : null;
@@ -700,5 +700,3 @@ class GetReportsReports implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetScheduledEmailByBatchId.php
+++ b/lib/Model/GetScheduledEmailByBatchId.php
@@ -180,7 +180,7 @@ class GetScheduledEmailByBatchId implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['count'] = isset($data['count']) ? $data['count'] : null;
         $this->container['batches'] = isset($data['batches']) ? $data['batches'] : null;
@@ -331,5 +331,3 @@ class GetScheduledEmailByBatchId implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetScheduledEmailByBatchIdBatches.php
+++ b/lib/Model/GetScheduledEmailByBatchIdBatches.php
@@ -204,7 +204,7 @@ class GetScheduledEmailByBatchIdBatches implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['scheduledAt'] = isset($data['scheduledAt']) ? $data['scheduledAt'] : null;
         $this->container['createdAt'] = isset($data['createdAt']) ? $data['createdAt'] : null;
@@ -406,5 +406,3 @@ class GetScheduledEmailByBatchIdBatches implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetScheduledEmailByMessageId.php
+++ b/lib/Model/GetScheduledEmailByMessageId.php
@@ -204,7 +204,7 @@ class GetScheduledEmailByMessageId implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['scheduledAt'] = isset($data['scheduledAt']) ? $data['scheduledAt'] : null;
         $this->container['createdAt'] = isset($data['createdAt']) ? $data['createdAt'] : null;
@@ -406,5 +406,3 @@ class GetScheduledEmailByMessageId implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetSegments.php
+++ b/lib/Model/GetSegments.php
@@ -180,7 +180,7 @@ class GetSegments implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['segments'] = isset($data['segments']) ? $data['segments'] : null;
         $this->container['count'] = isset($data['count']) ? $data['count'] : null;
@@ -331,5 +331,3 @@ class GetSegments implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetSegmentsSegments.php
+++ b/lib/Model/GetSegmentsSegments.php
@@ -190,7 +190,7 @@ class GetSegmentsSegments implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['segmentName'] = isset($data['segmentName']) ? $data['segmentName'] : null;
@@ -391,5 +391,3 @@ class GetSegmentsSegments implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetSendersList.php
+++ b/lib/Model/GetSendersList.php
@@ -175,7 +175,7 @@ class GetSendersList implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['senders'] = isset($data['senders']) ? $data['senders'] : null;
     }
@@ -301,5 +301,3 @@ class GetSendersList implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetSendersListIps.php
+++ b/lib/Model/GetSendersListIps.php
@@ -185,7 +185,7 @@ class GetSendersListIps implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['ip'] = isset($data['ip']) ? $data['ip'] : null;
         $this->container['domain'] = isset($data['domain']) ? $data['domain'] : null;
@@ -370,5 +370,3 @@ class GetSendersListIps implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetSendersListSenders.php
+++ b/lib/Model/GetSendersListSenders.php
@@ -195,7 +195,7 @@ class GetSendersListSenders implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
@@ -433,5 +433,3 @@ class GetSendersListSenders implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetSharedTemplateUrl.php
+++ b/lib/Model/GetSharedTemplateUrl.php
@@ -175,7 +175,7 @@ class GetSharedTemplateUrl implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['sharedUrl'] = isset($data['sharedUrl']) ? $data['sharedUrl'] : null;
     }
@@ -304,5 +304,3 @@ class GetSharedTemplateUrl implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetSmsCampaign.php
+++ b/lib/Model/GetSmsCampaign.php
@@ -243,7 +243,7 @@ class GetSmsCampaign implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
@@ -638,5 +638,3 @@ class GetSmsCampaign implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetSmsCampaignOverview.php
+++ b/lib/Model/GetSmsCampaignOverview.php
@@ -233,7 +233,7 @@ class GetSmsCampaignOverview implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
@@ -572,5 +572,3 @@ class GetSmsCampaignOverview implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetSmsCampaignRecipients.php
+++ b/lib/Model/GetSmsCampaignRecipients.php
@@ -175,7 +175,7 @@ class GetSmsCampaignRecipients implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
     }
 
@@ -276,5 +276,3 @@ class GetSmsCampaignRecipients implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetSmsCampaignStats.php
+++ b/lib/Model/GetSmsCampaignStats.php
@@ -205,7 +205,7 @@ class GetSmsCampaignStats implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['delivered'] = isset($data['delivered']) ? $data['delivered'] : null;
         $this->container['sent'] = isset($data['sent']) ? $data['sent'] : null;
@@ -502,5 +502,3 @@ class GetSmsCampaignStats implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetSmsCampaigns.php
+++ b/lib/Model/GetSmsCampaigns.php
@@ -180,7 +180,7 @@ class GetSmsCampaigns implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['campaigns'] = isset($data['campaigns']) ? $data['campaigns'] : null;
         $this->container['count'] = isset($data['count']) ? $data['count'] : null;
@@ -331,5 +331,3 @@ class GetSmsCampaigns implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetSmsEventReport.php
+++ b/lib/Model/GetSmsEventReport.php
@@ -175,7 +175,7 @@ class GetSmsEventReport implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['events'] = isset($data['events']) ? $data['events'] : null;
     }
@@ -301,5 +301,3 @@ class GetSmsEventReport implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetSmsEventReportEvents.php
+++ b/lib/Model/GetSmsEventReportEvents.php
@@ -236,7 +236,7 @@ class GetSmsEventReportEvents implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['phoneNumber'] = isset($data['phoneNumber']) ? $data['phoneNumber'] : null;
         $this->container['date'] = isset($data['date']) ? $data['date'] : null;
@@ -529,5 +529,3 @@ class GetSmsEventReportEvents implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetSmtpTemplateOverview.php
+++ b/lib/Model/GetSmtpTemplateOverview.php
@@ -235,7 +235,7 @@ class GetSmtpTemplateOverview implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
@@ -697,5 +697,3 @@ class GetSmtpTemplateOverview implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetSmtpTemplateOverviewSender.php
+++ b/lib/Model/GetSmtpTemplateOverviewSender.php
@@ -185,7 +185,7 @@ class GetSmtpTemplateOverviewSender implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
         $this->container['email'] = isset($data['email']) ? $data['email'] : null;
@@ -361,5 +361,3 @@ class GetSmtpTemplateOverviewSender implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetSmtpTemplates.php
+++ b/lib/Model/GetSmtpTemplates.php
@@ -180,7 +180,7 @@ class GetSmtpTemplates implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['count'] = isset($data['count']) ? $data['count'] : null;
         $this->container['templates'] = isset($data['templates']) ? $data['templates'] : null;
@@ -331,5 +331,3 @@ class GetSmtpTemplates implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetSsoToken.php
+++ b/lib/Model/GetSsoToken.php
@@ -175,7 +175,7 @@ class GetSsoToken implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['token'] = isset($data['token']) ? $data['token'] : null;
     }
@@ -304,5 +304,3 @@ class GetSsoToken implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetStatsByBrowser.php
+++ b/lib/Model/GetStatsByBrowser.php
@@ -175,7 +175,7 @@ class GetStatsByBrowser implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
     }
 
@@ -276,5 +276,3 @@ class GetStatsByBrowser implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetStatsByDevice.php
+++ b/lib/Model/GetStatsByDevice.php
@@ -190,7 +190,7 @@ class GetStatsByDevice implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['desktop'] = isset($data['desktop']) ? $data['desktop'] : null;
         $this->container['mobile'] = isset($data['mobile']) ? $data['mobile'] : null;
@@ -391,5 +391,3 @@ class GetStatsByDevice implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetStatsByDomain.php
+++ b/lib/Model/GetStatsByDomain.php
@@ -175,7 +175,7 @@ class GetStatsByDomain implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
     }
 
@@ -276,5 +276,3 @@ class GetStatsByDomain implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetTransacAggregatedSmsReport.php
+++ b/lib/Model/GetTransacAggregatedSmsReport.php
@@ -220,7 +220,7 @@ class GetTransacAggregatedSmsReport implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['range'] = isset($data['range']) ? $data['range'] : null;
         $this->container['requests'] = isset($data['requests']) ? $data['requests'] : null;
@@ -571,5 +571,3 @@ class GetTransacAggregatedSmsReport implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetTransacBlockedContacts.php
+++ b/lib/Model/GetTransacBlockedContacts.php
@@ -180,7 +180,7 @@ class GetTransacBlockedContacts implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['count'] = isset($data['count']) ? $data['count'] : null;
         $this->container['contacts'] = isset($data['contacts']) ? $data['contacts'] : null;
@@ -331,5 +331,3 @@ class GetTransacBlockedContacts implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetTransacBlockedContactsContacts.php
+++ b/lib/Model/GetTransacBlockedContactsContacts.php
@@ -190,7 +190,7 @@ class GetTransacBlockedContactsContacts implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['email'] = isset($data['email']) ? $data['email'] : null;
         $this->container['senderEmail'] = isset($data['senderEmail']) ? $data['senderEmail'] : null;
@@ -403,5 +403,3 @@ class GetTransacBlockedContactsContacts implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetTransacBlockedContactsReason.php
+++ b/lib/Model/GetTransacBlockedContactsReason.php
@@ -204,7 +204,7 @@ class GetTransacBlockedContactsReason implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['code'] = isset($data['code']) ? $data['code'] : null;
         $this->container['message'] = isset($data['message']) ? $data['message'] : null;
@@ -372,5 +372,3 @@ class GetTransacBlockedContactsReason implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetTransacEmailContent.php
+++ b/lib/Model/GetTransacEmailContent.php
@@ -205,7 +205,7 @@ class GetTransacEmailContent implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['email'] = isset($data['email']) ? $data['email'] : null;
         $this->container['subject'] = isset($data['subject']) ? $data['subject'] : null;
@@ -499,5 +499,3 @@ class GetTransacEmailContent implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetTransacEmailContentEvents.php
+++ b/lib/Model/GetTransacEmailContentEvents.php
@@ -180,7 +180,7 @@ class GetTransacEmailContentEvents implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
         $this->container['time'] = isset($data['time']) ? $data['time'] : null;
@@ -337,5 +337,3 @@ class GetTransacEmailContentEvents implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetTransacSmsReport.php
+++ b/lib/Model/GetTransacSmsReport.php
@@ -175,7 +175,7 @@ class GetTransacSmsReport implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['reports'] = isset($data['reports']) ? $data['reports'] : null;
     }
@@ -301,5 +301,3 @@ class GetTransacSmsReport implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetTransacSmsReportReports.php
+++ b/lib/Model/GetTransacSmsReportReports.php
@@ -220,7 +220,7 @@ class GetTransacSmsReportReports implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['date'] = isset($data['date']) ? $data['date'] : null;
         $this->container['requests'] = isset($data['requests']) ? $data['requests'] : null;
@@ -571,5 +571,3 @@ class GetTransacSmsReportReports implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetUserPermission.php
+++ b/lib/Model/GetUserPermission.php
@@ -186,7 +186,7 @@ class GetUserPermission implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['email'] = isset($data['email']) ? $data['email'] : null;
         $this->container['status'] = isset($data['status']) ? $data['status'] : null;
@@ -371,5 +371,3 @@ class GetUserPermission implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetUserPermissionPrivileges.php
+++ b/lib/Model/GetUserPermissionPrivileges.php
@@ -180,7 +180,7 @@ class GetUserPermissionPrivileges implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['feature'] = isset($data['feature']) ? $data['feature'] : null;
         $this->container['permissions'] = isset($data['permissions']) ? $data['permissions'] : null;
@@ -337,5 +337,3 @@ class GetUserPermissionPrivileges implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetWATemplates.php
+++ b/lib/Model/GetWATemplates.php
@@ -180,7 +180,7 @@ class GetWATemplates implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['templates'] = isset($data['templates']) ? $data['templates'] : null;
         $this->container['count'] = isset($data['count']) ? $data['count'] : null;
@@ -337,5 +337,3 @@ class GetWATemplates implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetWATemplatesTemplates.php
+++ b/lib/Model/GetWATemplatesTemplates.php
@@ -210,7 +210,7 @@ class GetWATemplatesTemplates implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
@@ -532,5 +532,3 @@ class GetWATemplatesTemplates implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetWebhook.php
+++ b/lib/Model/GetWebhook.php
@@ -235,7 +235,7 @@ class GetWebhook implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['url'] = isset($data['url']) ? $data['url'] : null;
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
@@ -624,5 +624,3 @@ class GetWebhook implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetWebhookAuth.php
+++ b/lib/Model/GetWebhookAuth.php
@@ -181,7 +181,7 @@ class GetWebhookAuth implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['type'] = isset($data['type']) ? $data['type'] : null;
         $this->container['token'] = isset($data['token']) ? $data['token'] : null;
@@ -332,5 +332,3 @@ class GetWebhookAuth implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetWebhookHeaders.php
+++ b/lib/Model/GetWebhookHeaders.php
@@ -180,7 +180,7 @@ class GetWebhookHeaders implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['key'] = isset($data['key']) ? $data['key'] : null;
         $this->container['value'] = isset($data['value']) ? $data['value'] : null;
@@ -331,5 +331,3 @@ class GetWebhookHeaders implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetWebhooks.php
+++ b/lib/Model/GetWebhooks.php
@@ -175,7 +175,7 @@ class GetWebhooks implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['webhooks'] = isset($data['webhooks']) ? $data['webhooks'] : null;
     }
@@ -304,5 +304,3 @@ class GetWebhooks implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetWhatsAppConfig.php
+++ b/lib/Model/GetWhatsAppConfig.php
@@ -234,7 +234,7 @@ class GetWhatsAppConfig implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['whatsappBusinessAccountId'] = isset($data['whatsappBusinessAccountId']) ? $data['whatsappBusinessAccountId'] : null;
         $this->container['sendingLimit'] = isset($data['sendingLimit']) ? $data['sendingLimit'] : null;
@@ -519,5 +519,3 @@ class GetWhatsAppConfig implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetWhatsappCampaignOverview.php
+++ b/lib/Model/GetWhatsappCampaignOverview.php
@@ -242,7 +242,7 @@ class GetWhatsappCampaignOverview implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['campaignName'] = isset($data['campaignName']) ? $data['campaignName'] : null;
@@ -606,5 +606,3 @@ class GetWhatsappCampaignOverview implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetWhatsappCampaigns.php
+++ b/lib/Model/GetWhatsappCampaigns.php
@@ -180,7 +180,7 @@ class GetWhatsappCampaigns implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['campaigns'] = isset($data['campaigns']) ? $data['campaigns'] : null;
         $this->container['count'] = isset($data['count']) ? $data['count'] : null;
@@ -331,5 +331,3 @@ class GetWhatsappCampaigns implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetWhatsappCampaignsCampaigns.php
+++ b/lib/Model/GetWhatsappCampaignsCampaigns.php
@@ -252,7 +252,7 @@ class GetWhatsappCampaignsCampaigns implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['campaignName'] = isset($data['campaignName']) ? $data['campaignName'] : null;
@@ -666,5 +666,3 @@ class GetWhatsappCampaignsCampaigns implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetWhatsappEventReport.php
+++ b/lib/Model/GetWhatsappEventReport.php
@@ -175,7 +175,7 @@ class GetWhatsappEventReport implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['events'] = isset($data['events']) ? $data['events'] : null;
     }
@@ -301,5 +301,3 @@ class GetWhatsappEventReport implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/GetWhatsappEventReportEvents.php
+++ b/lib/Model/GetWhatsappEventReportEvents.php
@@ -235,7 +235,7 @@ class GetWhatsappEventReportEvents implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['contactNumber'] = isset($data['contactNumber']) ? $data['contactNumber'] : null;
         $this->container['date'] = isset($data['date']) ? $data['date'] : null;
@@ -568,5 +568,3 @@ class GetWhatsappEventReportEvents implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/InlineResponse200.php
+++ b/lib/Model/InlineResponse200.php
@@ -180,7 +180,7 @@ class InlineResponse200 implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['groupName'] = isset($data['groupName']) ? $data['groupName'] : null;
@@ -331,5 +331,3 @@ class InlineResponse200 implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/InlineResponse2001.php
+++ b/lib/Model/InlineResponse2001.php
@@ -176,7 +176,7 @@ class InlineResponse2001 implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
     }
@@ -305,5 +305,3 @@ class InlineResponse2001 implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/InlineResponse2002.php
+++ b/lib/Model/InlineResponse2002.php
@@ -185,7 +185,7 @@ class InlineResponse2002 implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
@@ -370,5 +370,3 @@ class InlineResponse2002 implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/InlineResponse201.php
+++ b/lib/Model/InlineResponse201.php
@@ -175,7 +175,7 @@ class InlineResponse201 implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
     }
@@ -301,5 +301,3 @@ class InlineResponse201 implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/InlineResponse2011.php
+++ b/lib/Model/InlineResponse2011.php
@@ -176,7 +176,7 @@ class InlineResponse2011 implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
     }
@@ -305,5 +305,3 @@ class InlineResponse2011 implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/InlineResponse2012.php
+++ b/lib/Model/InlineResponse2012.php
@@ -176,7 +176,7 @@ class InlineResponse2012 implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
     }
@@ -305,5 +305,3 @@ class InlineResponse2012 implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/InlineResponse2013.php
+++ b/lib/Model/InlineResponse2013.php
@@ -175,7 +175,7 @@ class InlineResponse2013 implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
     }
@@ -304,5 +304,3 @@ class InlineResponse2013 implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/InlineResponse2014.php
+++ b/lib/Model/InlineResponse2014.php
@@ -175,7 +175,7 @@ class InlineResponse2014 implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['messageId'] = isset($data['messageId']) ? $data['messageId'] : null;
     }
@@ -304,5 +304,3 @@ class InlineResponse2014 implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/InlineResponse2015.php
+++ b/lib/Model/InlineResponse2015.php
@@ -175,7 +175,7 @@ class InlineResponse2015 implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
     }
@@ -304,5 +304,3 @@ class InlineResponse2015 implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/InviteAdminUser.php
+++ b/lib/Model/InviteAdminUser.php
@@ -190,7 +190,7 @@ class InviteAdminUser implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['email'] = isset($data['email']) ? $data['email'] : null;
         $this->container['allFeaturesAccess'] = isset($data['allFeaturesAccess']) ? $data['allFeaturesAccess'] : null;
@@ -400,5 +400,3 @@ class InviteAdminUser implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/InviteAdminUserPrivileges.php
+++ b/lib/Model/InviteAdminUserPrivileges.php
@@ -215,7 +215,7 @@ class InviteAdminUserPrivileges implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['feature'] = isset($data['feature']) ? $data['feature'] : null;
         $this->container['permissions'] = isset($data['permissions']) ? $data['permissions'] : null;
@@ -392,5 +392,3 @@ class InviteAdminUserPrivileges implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/Inviteuser.php
+++ b/lib/Model/Inviteuser.php
@@ -185,7 +185,7 @@ class Inviteuser implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['email'] = isset($data['email']) ? $data['email'] : null;
         $this->container['allFeaturesAccess'] = isset($data['allFeaturesAccess']) ? $data['allFeaturesAccess'] : null;
@@ -370,5 +370,3 @@ class Inviteuser implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/InviteuserPrivileges.php
+++ b/lib/Model/InviteuserPrivileges.php
@@ -287,7 +287,7 @@ class InviteuserPrivileges implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['feature'] = isset($data['feature']) ? $data['feature'] : null;
         $this->container['permissions'] = isset($data['permissions']) ? $data['permissions'] : null;
@@ -464,5 +464,3 @@ class InviteuserPrivileges implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/ManageIp.php
+++ b/lib/Model/ManageIp.php
@@ -175,7 +175,7 @@ class ManageIp implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['ip'] = isset($data['ip']) ? $data['ip'] : null;
     }
@@ -301,5 +301,3 @@ class ManageIp implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/MasterDetailsResponse.php
+++ b/lib/Model/MasterDetailsResponse.php
@@ -205,7 +205,7 @@ class MasterDetailsResponse implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['email'] = isset($data['email']) ? $data['email'] : null;
         $this->container['companyName'] = isset($data['companyName']) ? $data['companyName'] : null;
@@ -481,5 +481,3 @@ class MasterDetailsResponse implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/MasterDetailsResponseBillingInfo.php
+++ b/lib/Model/MasterDetailsResponseBillingInfo.php
@@ -191,7 +191,7 @@ class MasterDetailsResponseBillingInfo implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['email'] = isset($data['email']) ? $data['email'] : null;
         $this->container['companyName'] = isset($data['companyName']) ? $data['companyName'] : null;
@@ -392,5 +392,3 @@ class MasterDetailsResponseBillingInfo implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/MasterDetailsResponseBillingInfoAddress.php
+++ b/lib/Model/MasterDetailsResponseBillingInfoAddress.php
@@ -196,7 +196,7 @@ class MasterDetailsResponseBillingInfoAddress implements ModelInterface, ArrayAc
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['streetAddress'] = isset($data['streetAddress']) ? $data['streetAddress'] : null;
         $this->container['locality'] = isset($data['locality']) ? $data['locality'] : null;
@@ -422,5 +422,3 @@ class MasterDetailsResponseBillingInfoAddress implements ModelInterface, ArrayAc
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/MasterDetailsResponseBillingInfoName.php
+++ b/lib/Model/MasterDetailsResponseBillingInfoName.php
@@ -181,7 +181,7 @@ class MasterDetailsResponseBillingInfoName implements ModelInterface, ArrayAcces
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['givenName'] = isset($data['givenName']) ? $data['givenName'] : null;
         $this->container['familyName'] = isset($data['familyName']) ? $data['familyName'] : null;
@@ -332,5 +332,3 @@ class MasterDetailsResponseBillingInfoName implements ModelInterface, ArrayAcces
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/MasterDetailsResponsePlanInfo.php
+++ b/lib/Model/MasterDetailsResponsePlanInfo.php
@@ -216,7 +216,7 @@ class MasterDetailsResponsePlanInfo implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['currencyCode'] = isset($data['currencyCode']) ? $data['currencyCode'] : null;
         $this->container['nextBillingAt'] = isset($data['nextBillingAt']) ? $data['nextBillingAt'] : null;
@@ -484,5 +484,3 @@ class MasterDetailsResponsePlanInfo implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/MasterDetailsResponsePlanInfoFeatures.php
+++ b/lib/Model/MasterDetailsResponsePlanInfoFeatures.php
@@ -205,7 +205,7 @@ class MasterDetailsResponsePlanInfoFeatures implements ModelInterface, ArrayAcce
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
         $this->container['unitValue'] = isset($data['unitValue']) ? $data['unitValue'] : null;
@@ -481,5 +481,3 @@ class MasterDetailsResponsePlanInfoFeatures implements ModelInterface, ArrayAcce
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/Note.php
+++ b/lib/Model/Note.php
@@ -206,7 +206,7 @@ class Note implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['text'] = isset($data['text']) ? $data['text'] : null;
@@ -500,5 +500,3 @@ class Note implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/NoteData.php
+++ b/lib/Model/NoteData.php
@@ -191,7 +191,7 @@ class NoteData implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['text'] = isset($data['text']) ? $data['text'] : null;
         $this->container['contactIds'] = isset($data['contactIds']) ? $data['contactIds'] : null;
@@ -410,5 +410,3 @@ class NoteData implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/NoteId.php
+++ b/lib/Model/NoteId.php
@@ -176,7 +176,7 @@ class NoteId implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
     }
@@ -302,5 +302,3 @@ class NoteId implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/NoteList.php
+++ b/lib/Model/NoteList.php
@@ -176,7 +176,7 @@ class NoteList implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
     }
 
@@ -277,5 +277,3 @@ class NoteList implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/Order.php
+++ b/lib/Model/Order.php
@@ -215,7 +215,7 @@ class Order implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['createdAt'] = isset($data['createdAt']) ? $data['createdAt'] : null;
@@ -559,5 +559,3 @@ class Order implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/OrderBatch.php
+++ b/lib/Model/OrderBatch.php
@@ -185,7 +185,7 @@ class OrderBatch implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['orders'] = isset($data['orders']) ? $data['orders'] : null;
         $this->container['notifyUrl'] = isset($data['notifyUrl']) ? $data['notifyUrl'] : null;
@@ -364,5 +364,3 @@ class OrderBatch implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/OrderBilling.php
+++ b/lib/Model/OrderBilling.php
@@ -206,7 +206,7 @@ class OrderBilling implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['address'] = isset($data['address']) ? $data['address'] : null;
         $this->container['city'] = isset($data['city']) ? $data['city'] : null;
@@ -482,5 +482,3 @@ class OrderBilling implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/OrderProducts.php
+++ b/lib/Model/OrderProducts.php
@@ -191,7 +191,7 @@ class OrderProducts implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['productId'] = isset($data['productId']) ? $data['productId'] : null;
         $this->container['quantity'] = isset($data['quantity']) ? $data['quantity'] : null;
@@ -401,5 +401,3 @@ class OrderProducts implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/Otp.php
+++ b/lib/Model/Otp.php
@@ -175,7 +175,7 @@ class Otp implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
     }
@@ -301,5 +301,3 @@ class Otp implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/Pipeline.php
+++ b/lib/Model/Pipeline.php
@@ -186,7 +186,7 @@ class Pipeline implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['pipeline'] = isset($data['pipeline']) ? $data['pipeline'] : null;
         $this->container['pipelineName'] = isset($data['pipelineName']) ? $data['pipelineName'] : null;
@@ -362,5 +362,3 @@ class Pipeline implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/PipelineStage.php
+++ b/lib/Model/PipelineStage.php
@@ -181,7 +181,7 @@ class PipelineStage implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
@@ -332,5 +332,3 @@ class PipelineStage implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/Pipelines.php
+++ b/lib/Model/Pipelines.php
@@ -176,7 +176,7 @@ class Pipelines implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
     }
 
@@ -277,5 +277,3 @@ class Pipelines implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/PostContactInfo.php
+++ b/lib/Model/PostContactInfo.php
@@ -175,7 +175,7 @@ class PostContactInfo implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['contacts'] = isset($data['contacts']) ? $data['contacts'] : null;
     }
@@ -304,5 +304,3 @@ class PostContactInfo implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/PostContactInfoContacts.php
+++ b/lib/Model/PostContactInfoContacts.php
@@ -190,7 +190,7 @@ class PostContactInfoContacts implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['success'] = isset($data['success']) ? $data['success'] : null;
         $this->container['failure'] = isset($data['failure']) ? $data['failure'] : null;
@@ -391,5 +391,3 @@ class PostContactInfoContacts implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/PostSendFailed.php
+++ b/lib/Model/PostSendFailed.php
@@ -195,7 +195,7 @@ class PostSendFailed implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['code'] = isset($data['code']) ? $data['code'] : null;
         $this->container['message'] = isset($data['message']) ? $data['message'] : null;
@@ -427,5 +427,3 @@ class PostSendFailed implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/PostSendSmsTestFailed.php
+++ b/lib/Model/PostSendSmsTestFailed.php
@@ -190,7 +190,7 @@ class PostSendSmsTestFailed implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['code'] = isset($data['code']) ? $data['code'] : null;
         $this->container['message'] = isset($data['message']) ? $data['message'] : null;
@@ -397,5 +397,3 @@ class PostSendSmsTestFailed implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/PutRevokeUserPermission.php
+++ b/lib/Model/PutRevokeUserPermission.php
@@ -176,7 +176,7 @@ class PutRevokeUserPermission implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['email'] = isset($data['email']) ? $data['email'] : null;
     }
@@ -305,5 +305,3 @@ class PutRevokeUserPermission implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/Putresendcancelinvitation.php
+++ b/lib/Model/Putresendcancelinvitation.php
@@ -176,7 +176,7 @@ class Putresendcancelinvitation implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['email'] = isset($data['email']) ? $data['email'] : null;
     }
@@ -305,5 +305,3 @@ class Putresendcancelinvitation implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/RemainingCreditModel.php
+++ b/lib/Model/RemainingCreditModel.php
@@ -180,7 +180,7 @@ class RemainingCreditModel implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['child'] = isset($data['child']) ? $data['child'] : null;
         $this->container['reseller'] = isset($data['reseller']) ? $data['reseller'] : null;
@@ -337,5 +337,3 @@ class RemainingCreditModel implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/RemainingCreditModelChild.php
+++ b/lib/Model/RemainingCreditModelChild.php
@@ -181,7 +181,7 @@ class RemainingCreditModelChild implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['sms'] = isset($data['sms']) ? $data['sms'] : null;
         $this->container['email'] = isset($data['email']) ? $data['email'] : null;
@@ -338,5 +338,3 @@ class RemainingCreditModelChild implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/RemainingCreditModelReseller.php
+++ b/lib/Model/RemainingCreditModelReseller.php
@@ -180,7 +180,7 @@ class RemainingCreditModelReseller implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['sms'] = isset($data['sms']) ? $data['sms'] : null;
         $this->container['email'] = isset($data['email']) ? $data['email'] : null;
@@ -337,5 +337,3 @@ class RemainingCreditModelReseller implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/RemoveContactFromList.php
+++ b/lib/Model/RemoveContactFromList.php
@@ -187,7 +187,7 @@ class RemoveContactFromList implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['emails'] = isset($data['emails']) ? $data['emails'] : null;
         $this->container['ids'] = isset($data['ids']) ? $data['ids'] : null;

--- a/lib/Model/RemoveCredits.php
+++ b/lib/Model/RemoveCredits.php
@@ -180,7 +180,7 @@ class RemoveCredits implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['sms'] = isset($data['sms']) ? $data['sms'] : null;
         $this->container['email'] = isset($data['email']) ? $data['email'] : null;
@@ -331,5 +331,3 @@ class RemoveCredits implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/RequestContactExport.php
+++ b/lib/Model/RequestContactExport.php
@@ -202,7 +202,7 @@ class RequestContactExport implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['exportAttributes'] = isset($data['exportAttributes']) ? $data['exportAttributes'] : null;
         $this->container['customContactFilter'] = isset($data['customContactFilter']) ? $data['customContactFilter'] : null;

--- a/lib/Model/RequestContactExportCustomContactFilter.php
+++ b/lib/Model/RequestContactExportCustomContactFilter.php
@@ -262,7 +262,7 @@ class RequestContactExportCustomContactFilter implements ModelInterface, ArrayAc
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['actionForContacts'] = isset($data['actionForContacts']) ? $data['actionForContacts'] : null;
         $this->container['actionForEmailCampaigns'] = isset($data['actionForEmailCampaigns']) ? $data['actionForEmailCampaigns'] : null;
@@ -564,5 +564,3 @@ class RequestContactExportCustomContactFilter implements ModelInterface, ArrayAc
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/RequestContactImport.php
+++ b/lib/Model/RequestContactImport.php
@@ -222,7 +222,7 @@ class RequestContactImport implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['fileUrl'] = isset($data['fileUrl']) ? $data['fileUrl'] : null;
         $this->container['fileBody'] = isset($data['fileBody']) ? $data['fileBody'] : null;

--- a/lib/Model/RequestContactImportJsonBody.php
+++ b/lib/Model/RequestContactImportJsonBody.php
@@ -180,7 +180,7 @@ class RequestContactImportJsonBody implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['email'] = isset($data['email']) ? $data['email'] : null;
         $this->container['attributes'] = isset($data['attributes']) ? $data['attributes'] : null;
@@ -331,5 +331,3 @@ class RequestContactImportJsonBody implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/RequestContactImportNewList.php
+++ b/lib/Model/RequestContactImportNewList.php
@@ -181,7 +181,7 @@ class RequestContactImportNewList implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['listName'] = isset($data['listName']) ? $data['listName'] : null;
         $this->container['folderId'] = isset($data['folderId']) ? $data['folderId'] : null;
@@ -332,5 +332,3 @@ class RequestContactImportNewList implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/RequestSmsRecipientExport.php
+++ b/lib/Model/RequestSmsRecipientExport.php
@@ -203,7 +203,7 @@ class RequestSmsRecipientExport implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['notifyURL'] = isset($data['notifyURL']) ? $data['notifyURL'] : null;
         $this->container['recipientsType'] = isset($data['recipientsType']) ? $data['recipientsType'] : null;
@@ -374,5 +374,3 @@ class RequestSmsRecipientExport implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/ScheduleSmtpEmail.php
+++ b/lib/Model/ScheduleSmtpEmail.php
@@ -185,7 +185,7 @@ class ScheduleSmtpEmail implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['messageId'] = isset($data['messageId']) ? $data['messageId'] : null;
         $this->container['messageIds'] = isset($data['messageIds']) ? $data['messageIds'] : null;
@@ -361,5 +361,3 @@ class ScheduleSmtpEmail implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/SendReport.php
+++ b/lib/Model/SendReport.php
@@ -203,7 +203,7 @@ class SendReport implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['language'] = isset($data['language']) ? $data['language'] : 'fr';
         $this->container['email'] = isset($data['email']) ? $data['email'] : null;
@@ -374,5 +374,3 @@ class SendReport implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/SendReportEmail.php
+++ b/lib/Model/SendReportEmail.php
@@ -181,7 +181,7 @@ class SendReportEmail implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['to'] = isset($data['to']) ? $data['to'] : null;
         $this->container['body'] = isset($data['body']) ? $data['body'] : null;
@@ -338,5 +338,3 @@ class SendReportEmail implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/SendSms.php
+++ b/lib/Model/SendSms.php
@@ -192,7 +192,7 @@ class SendSms implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['reference'] = isset($data['reference']) ? $data['reference'] : null;
         $this->container['messageId'] = isset($data['messageId']) ? $data['messageId'] : null;

--- a/lib/Model/SendTestSms.php
+++ b/lib/Model/SendTestSms.php
@@ -172,7 +172,7 @@ class SendTestSms implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['phoneNumber'] = isset($data['phoneNumber']) ? $data['phoneNumber'] : null;
     }

--- a/lib/Model/SendTransacSms.php
+++ b/lib/Model/SendTransacSms.php
@@ -221,7 +221,7 @@ class SendTransacSms implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['sender'] = isset($data['sender']) ? $data['sender'] : null;
         $this->container['recipient'] = isset($data['recipient']) ? $data['recipient'] : null;

--- a/lib/Model/SendTransacSmsTag.php
+++ b/lib/Model/SendTransacSmsTag.php
@@ -173,7 +173,7 @@ class SendTransacSmsTag implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['field'] = isset($data['field']) ? $data['field'] : null;
     }

--- a/lib/Model/SendWhatsappMessage.php
+++ b/lib/Model/SendWhatsappMessage.php
@@ -195,7 +195,7 @@ class SendWhatsappMessage implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['templateId'] = isset($data['templateId']) ? $data['templateId'] : null;
         $this->container['text'] = isset($data['text']) ? $data['text'] : null;
@@ -427,5 +427,3 @@ class SendWhatsappMessage implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/SsoTokenRequest.php
+++ b/lib/Model/SsoTokenRequest.php
@@ -217,7 +217,7 @@ class SsoTokenRequest implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['email'] = isset($data['email']) ? $data['email'] : null;
@@ -438,5 +438,3 @@ class SsoTokenRequest implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/SubAccountAppsToggleRequest.php
+++ b/lib/Model/SubAccountAppsToggleRequest.php
@@ -236,7 +236,7 @@ class SubAccountAppsToggleRequest implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['inbox'] = isset($data['inbox']) ? $data['inbox'] : null;
         $this->container['whatsapp'] = isset($data['whatsapp']) ? $data['whatsapp'] : null;
@@ -662,5 +662,3 @@ class SubAccountAppsToggleRequest implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/SubAccountDetailsResponse.php
+++ b/lib/Model/SubAccountDetailsResponse.php
@@ -190,7 +190,7 @@ class SubAccountDetailsResponse implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
         $this->container['email'] = isset($data['email']) ? $data['email'] : null;
@@ -391,5 +391,3 @@ class SubAccountDetailsResponse implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/SubAccountDetailsResponsePlanInfo.php
+++ b/lib/Model/SubAccountDetailsResponsePlanInfo.php
@@ -186,7 +186,7 @@ class SubAccountDetailsResponsePlanInfo implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['credits'] = isset($data['credits']) ? $data['credits'] : null;
         $this->container['features'] = isset($data['features']) ? $data['features'] : null;
@@ -362,5 +362,3 @@ class SubAccountDetailsResponsePlanInfo implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/SubAccountDetailsResponsePlanInfoCredits.php
+++ b/lib/Model/SubAccountDetailsResponsePlanInfoCredits.php
@@ -181,7 +181,7 @@ class SubAccountDetailsResponsePlanInfoCredits implements ModelInterface, ArrayA
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['sms'] = isset($data['sms']) ? $data['sms'] : null;
         $this->container['emails'] = isset($data['emails']) ? $data['emails'] : null;
@@ -332,5 +332,3 @@ class SubAccountDetailsResponsePlanInfoCredits implements ModelInterface, ArrayA
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/SubAccountDetailsResponsePlanInfoCreditsEmails.php
+++ b/lib/Model/SubAccountDetailsResponsePlanInfoCreditsEmails.php
@@ -181,7 +181,7 @@ class SubAccountDetailsResponsePlanInfoCreditsEmails implements ModelInterface, 
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['quantity'] = isset($data['quantity']) ? $data['quantity'] : null;
         $this->container['remaining'] = isset($data['remaining']) ? $data['remaining'] : null;
@@ -332,5 +332,3 @@ class SubAccountDetailsResponsePlanInfoCreditsEmails implements ModelInterface, 
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/SubAccountDetailsResponsePlanInfoFeatures.php
+++ b/lib/Model/SubAccountDetailsResponsePlanInfoFeatures.php
@@ -186,7 +186,7 @@ class SubAccountDetailsResponsePlanInfoFeatures implements ModelInterface, Array
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['inbox'] = isset($data['inbox']) ? $data['inbox'] : null;
         $this->container['landingPage'] = isset($data['landingPage']) ? $data['landingPage'] : null;
@@ -362,5 +362,3 @@ class SubAccountDetailsResponsePlanInfoFeatures implements ModelInterface, Array
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/SubAccountDetailsResponsePlanInfoFeaturesInbox.php
+++ b/lib/Model/SubAccountDetailsResponsePlanInfoFeaturesInbox.php
@@ -181,7 +181,7 @@ class SubAccountDetailsResponsePlanInfoFeaturesInbox implements ModelInterface, 
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['quantity'] = isset($data['quantity']) ? $data['quantity'] : null;
         $this->container['remaining'] = isset($data['remaining']) ? $data['remaining'] : null;
@@ -332,5 +332,3 @@ class SubAccountDetailsResponsePlanInfoFeaturesInbox implements ModelInterface, 
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/SubAccountDetailsResponsePlanInfoFeaturesLandingPage.php
+++ b/lib/Model/SubAccountDetailsResponsePlanInfoFeaturesLandingPage.php
@@ -181,7 +181,7 @@ class SubAccountDetailsResponsePlanInfoFeaturesLandingPage implements ModelInter
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['quantity'] = isset($data['quantity']) ? $data['quantity'] : null;
         $this->container['remaining'] = isset($data['remaining']) ? $data['remaining'] : null;
@@ -332,5 +332,3 @@ class SubAccountDetailsResponsePlanInfoFeaturesLandingPage implements ModelInter
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/SubAccountDetailsResponsePlanInfoFeaturesUsers.php
+++ b/lib/Model/SubAccountDetailsResponsePlanInfoFeaturesUsers.php
@@ -181,7 +181,7 @@ class SubAccountDetailsResponsePlanInfoFeaturesUsers implements ModelInterface, 
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['quantity'] = isset($data['quantity']) ? $data['quantity'] : null;
         $this->container['remaining'] = isset($data['remaining']) ? $data['remaining'] : null;
@@ -332,5 +332,3 @@ class SubAccountDetailsResponsePlanInfoFeaturesUsers implements ModelInterface, 
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/SubAccountUpdatePlanRequest.php
+++ b/lib/Model/SubAccountUpdatePlanRequest.php
@@ -181,7 +181,7 @@ class SubAccountUpdatePlanRequest implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['credits'] = isset($data['credits']) ? $data['credits'] : null;
         $this->container['features'] = isset($data['features']) ? $data['features'] : null;
@@ -332,5 +332,3 @@ class SubAccountUpdatePlanRequest implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/SubAccountUpdatePlanRequestCredits.php
+++ b/lib/Model/SubAccountUpdatePlanRequestCredits.php
@@ -176,7 +176,7 @@ class SubAccountUpdatePlanRequestCredits implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['email'] = isset($data['email']) ? $data['email'] : null;
     }
@@ -302,5 +302,3 @@ class SubAccountUpdatePlanRequestCredits implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/SubAccountUpdatePlanRequestFeatures.php
+++ b/lib/Model/SubAccountUpdatePlanRequestFeatures.php
@@ -186,7 +186,7 @@ class SubAccountUpdatePlanRequestFeatures implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['users'] = isset($data['users']) ? $data['users'] : null;
         $this->container['landingPage'] = isset($data['landingPage']) ? $data['landingPage'] : null;
@@ -362,5 +362,3 @@ class SubAccountUpdatePlanRequestFeatures implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/SubAccountsResponse.php
+++ b/lib/Model/SubAccountsResponse.php
@@ -180,7 +180,7 @@ class SubAccountsResponse implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['count'] = isset($data['count']) ? $data['count'] : null;
         $this->container['subAccounts'] = isset($data['subAccounts']) ? $data['subAccounts'] : null;
@@ -331,5 +331,3 @@ class SubAccountsResponse implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/SubAccountsResponseSubAccounts.php
+++ b/lib/Model/SubAccountsResponseSubAccounts.php
@@ -190,7 +190,7 @@ class SubAccountsResponseSubAccounts implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['companyName'] = isset($data['companyName']) ? $data['companyName'] : null;
@@ -403,5 +403,3 @@ class SubAccountsResponseSubAccounts implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/Task.php
+++ b/lib/Model/Task.php
@@ -201,7 +201,7 @@ class Task implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['taskTypeId'] = isset($data['taskTypeId']) ? $data['taskTypeId'] : null;
@@ -458,5 +458,3 @@ class Task implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/TaskList.php
+++ b/lib/Model/TaskList.php
@@ -176,7 +176,7 @@ class TaskList implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['items'] = isset($data['items']) ? $data['items'] : null;
     }
@@ -302,5 +302,3 @@ class TaskList implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/TaskReminder.php
+++ b/lib/Model/TaskReminder.php
@@ -205,7 +205,7 @@ class TaskReminder implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['value'] = isset($data['value']) ? $data['value'] : null;
         $this->container['unit'] = isset($data['unit']) ? $data['unit'] : null;
@@ -407,5 +407,3 @@ class TaskReminder implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/TaskTypes.php
+++ b/lib/Model/TaskTypes.php
@@ -181,7 +181,7 @@ class TaskTypes implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
         $this->container['title'] = isset($data['title']) ? $data['title'] : null;
@@ -332,5 +332,3 @@ class TaskTypes implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/UpdateAttribute.php
+++ b/lib/Model/UpdateAttribute.php
@@ -185,7 +185,7 @@ class UpdateAttribute implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['value'] = isset($data['value']) ? $data['value'] : null;
         $this->container['enumeration'] = isset($data['enumeration']) ? $data['enumeration'] : null;
@@ -361,5 +361,3 @@ class UpdateAttribute implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/UpdateAttributeEnumeration.php
+++ b/lib/Model/UpdateAttributeEnumeration.php
@@ -180,7 +180,7 @@ class UpdateAttributeEnumeration implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['value'] = isset($data['value']) ? $data['value'] : null;
         $this->container['label'] = isset($data['label']) ? $data['label'] : null;
@@ -337,5 +337,3 @@ class UpdateAttributeEnumeration implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/UpdateBatchContacts.php
+++ b/lib/Model/UpdateBatchContacts.php
@@ -175,7 +175,7 @@ class UpdateBatchContacts implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['contacts'] = isset($data['contacts']) ? $data['contacts'] : null;
     }
@@ -301,5 +301,3 @@ class UpdateBatchContacts implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/UpdateBatchContactsContacts.php
+++ b/lib/Model/UpdateBatchContactsContacts.php
@@ -220,7 +220,7 @@ class UpdateBatchContactsContacts implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['email'] = isset($data['email']) ? $data['email'] : null;
         $this->container['id'] = isset($data['id']) ? $data['id'] : null;
@@ -571,5 +571,3 @@ class UpdateBatchContactsContacts implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/UpdateBatchContactsModel.php
+++ b/lib/Model/UpdateBatchContactsModel.php
@@ -180,7 +180,7 @@ class UpdateBatchContactsModel implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['successIds'] = isset($data['successIds']) ? $data['successIds'] : null;
         $this->container['failureIds'] = isset($data['failureIds']) ? $data['failureIds'] : null;
@@ -331,5 +331,3 @@ class UpdateBatchContactsModel implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/UpdateCampaignStatus.php
+++ b/lib/Model/UpdateCampaignStatus.php
@@ -203,7 +203,7 @@ class UpdateCampaignStatus implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['status'] = isset($data['status']) ? $data['status'] : null;
     }
@@ -346,5 +346,3 @@ class UpdateCampaignStatus implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/UpdateChild.php
+++ b/lib/Model/UpdateChild.php
@@ -195,7 +195,7 @@ class UpdateChild implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['email'] = isset($data['email']) ? $data['email'] : null;
         $this->container['firstName'] = isset($data['firstName']) ? $data['firstName'] : null;
@@ -421,5 +421,3 @@ class UpdateChild implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/UpdateChildAccountStatus.php
+++ b/lib/Model/UpdateChildAccountStatus.php
@@ -190,7 +190,7 @@ class UpdateChildAccountStatus implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['transactionalEmail'] = isset($data['transactionalEmail']) ? $data['transactionalEmail'] : null;
         $this->container['transactionalSms'] = isset($data['transactionalSms']) ? $data['transactionalSms'] : null;
@@ -391,5 +391,3 @@ class UpdateChildAccountStatus implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/UpdateChildDomain.php
+++ b/lib/Model/UpdateChildDomain.php
@@ -175,7 +175,7 @@ class UpdateChildDomain implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['domain'] = isset($data['domain']) ? $data['domain'] : null;
     }
@@ -301,5 +301,3 @@ class UpdateChildDomain implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/UpdateContact.php
+++ b/lib/Model/UpdateContact.php
@@ -202,7 +202,7 @@ class UpdateContact implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['attributes'] = isset($data['attributes']) ? $data['attributes'] : null;
         $this->container['extId'] = isset($data['extId']) ? $data['extId'] : null;

--- a/lib/Model/UpdateCouponCollection.php
+++ b/lib/Model/UpdateCouponCollection.php
@@ -175,7 +175,7 @@ class UpdateCouponCollection implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['defaultCoupon'] = isset($data['defaultCoupon']) ? $data['defaultCoupon'] : null;
     }
@@ -304,5 +304,3 @@ class UpdateCouponCollection implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/UpdateEmailCampaign.php
+++ b/lib/Model/UpdateEmailCampaign.php
@@ -340,7 +340,7 @@ class UpdateEmailCampaign implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['tag'] = isset($data['tag']) ? $data['tag'] : null;
         $this->container['sender'] = isset($data['sender']) ? $data['sender'] : null;
@@ -1281,5 +1281,3 @@ class UpdateEmailCampaign implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/UpdateEmailCampaignRecipients.php
+++ b/lib/Model/UpdateEmailCampaignRecipients.php
@@ -186,7 +186,7 @@ class UpdateEmailCampaignRecipients implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['exclusionListIds'] = isset($data['exclusionListIds']) ? $data['exclusionListIds'] : null;
         $this->container['listIds'] = isset($data['listIds']) ? $data['listIds'] : null;
@@ -362,5 +362,3 @@ class UpdateEmailCampaignRecipients implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/UpdateEmailCampaignSender.php
+++ b/lib/Model/UpdateEmailCampaignSender.php
@@ -186,7 +186,7 @@ class UpdateEmailCampaignSender implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
         $this->container['email'] = isset($data['email']) ? $data['email'] : null;
@@ -362,5 +362,3 @@ class UpdateEmailCampaignSender implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/UpdateExternalFeed.php
+++ b/lib/Model/UpdateExternalFeed.php
@@ -232,7 +232,7 @@ class UpdateExternalFeed implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
         $this->container['url'] = isset($data['url']) ? $data['url'] : null;
@@ -591,5 +591,3 @@ class UpdateExternalFeed implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/UpdateList.php
+++ b/lib/Model/UpdateList.php
@@ -180,7 +180,7 @@ class UpdateList implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
         $this->container['folderId'] = isset($data['folderId']) ? $data['folderId'] : null;
@@ -331,5 +331,3 @@ class UpdateList implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/UpdateSender.php
+++ b/lib/Model/UpdateSender.php
@@ -185,7 +185,7 @@ class UpdateSender implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
         $this->container['email'] = isset($data['email']) ? $data['email'] : null;
@@ -361,5 +361,3 @@ class UpdateSender implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/UpdateSmsCampaign.php
+++ b/lib/Model/UpdateSmsCampaign.php
@@ -210,7 +210,7 @@ class UpdateSmsCampaign implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
         $this->container['sender'] = isset($data['sender']) ? $data['sender'] : null;
@@ -519,5 +519,3 @@ class UpdateSmsCampaign implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/UpdateSmtpTemplate.php
+++ b/lib/Model/UpdateSmtpTemplate.php
@@ -220,7 +220,7 @@ class UpdateSmtpTemplate implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['tag'] = isset($data['tag']) ? $data['tag'] : null;
         $this->container['sender'] = isset($data['sender']) ? $data['sender'] : null;
@@ -571,5 +571,3 @@ class UpdateSmtpTemplate implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/UpdateSmtpTemplateSender.php
+++ b/lib/Model/UpdateSmtpTemplateSender.php
@@ -186,7 +186,7 @@ class UpdateSmtpTemplateSender implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
         $this->container['email'] = isset($data['email']) ? $data['email'] : null;
@@ -362,5 +362,3 @@ class UpdateSmtpTemplateSender implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/UpdateWebhook.php
+++ b/lib/Model/UpdateWebhook.php
@@ -250,7 +250,7 @@ class UpdateWebhook implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['url'] = isset($data['url']) ? $data['url'] : null;
         $this->container['description'] = isset($data['description']) ? $data['description'] : null;
@@ -535,5 +535,3 @@ class UpdateWebhook implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/UpdateWhatsAppCampaign.php
+++ b/lib/Model/UpdateWhatsAppCampaign.php
@@ -205,7 +205,7 @@ class UpdateWhatsAppCampaign implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['campaignName'] = isset($data['campaignName']) ? $data['campaignName'] : null;
         $this->container['campaignStatus'] = isset($data['campaignStatus']) ? $data['campaignStatus'] : 'scheduled';
@@ -423,5 +423,3 @@ class UpdateWhatsAppCampaign implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/UploadImageModel.php
+++ b/lib/Model/UploadImageModel.php
@@ -175,7 +175,7 @@ class UploadImageModel implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['url'] = isset($data['url']) ? $data['url'] : null;
     }
@@ -304,5 +304,3 @@ class UploadImageModel implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/UploadImageToGallery.php
+++ b/lib/Model/UploadImageToGallery.php
@@ -180,7 +180,7 @@ class UploadImageToGallery implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['imageUrl'] = isset($data['imageUrl']) ? $data['imageUrl'] : null;
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
@@ -334,5 +334,3 @@ class UploadImageToGallery implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/VariablesItems.php
+++ b/lib/Model/VariablesItems.php
@@ -185,7 +185,7 @@ class VariablesItems implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
         $this->container['default'] = isset($data['default']) ? $data['default'] : null;
@@ -361,5 +361,3 @@ class VariablesItems implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/WhatsappCampStats.php
+++ b/lib/Model/WhatsappCampStats.php
@@ -195,7 +195,7 @@ class WhatsappCampStats implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['sent'] = isset($data['sent']) ? $data['sent'] : null;
         $this->container['delivered'] = isset($data['delivered']) ? $data['delivered'] : null;
@@ -436,5 +436,3 @@ class WhatsappCampStats implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-

--- a/lib/Model/WhatsappCampTemplate.php
+++ b/lib/Model/WhatsappCampTemplate.php
@@ -225,7 +225,7 @@ class WhatsappCampTemplate implements ModelInterface, ArrayAccess
      * @param mixed[] $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['name'] = isset($data['name']) ? $data['name'] : null;
         $this->container['category'] = isset($data['category']) ? $data['category'] : null;
@@ -601,5 +601,3 @@ class WhatsappCampTemplate implements ModelInterface, ArrayAccess
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }
 }
-
-


### PR DESCRIPTION
- Implicitly marking parameter $data as nullable is deprecated, the explicit nullable type must be used instead
- Return type should either be compatible with declaration => add #[\ReturnTypeWillChange] attribute to temporarily suppress the notice

PHP 5.6 compatibility has already been broken several times:

Nullable types only appeared with PHP 7.1, but they are already used in several classes (https://github.com/getbrevo/brevo-php/commit/03dddf3cf18c32636d62088a9b2170a21d052173, for example).

It may be necessary to modify the composer.json, since as it stands, version 2.0.14 is not compatible with PHP 5.6.