### PR TITLE
feat(smtp): add contactPixelTrackingConsent to transactional email recipients

### DIFF
--- a/src/TransactionalEmails/Types/SendTransacEmailRequestBccItem.php
+++ b/src/TransactionalEmails/Types/SendTransacEmailRequestBccItem.php
@@ -8,6 +8,12 @@ use Brevo\Core\Json\JsonProperty;
 class SendTransacEmailRequestBccItem extends JsonSerializableType
 {
     /**
+     * @var ?bool $contactPixelTrackingConsent Consent of the recipient in bcc for open (pixel) and click tracking, resolved by the sender at send time. Considered only if the per-contact pixel tracking consent feature is enabled for your account. Pass `true` if this recipient has consented to open and click tracking, in which case the open pixel and tracked links identify the recipient. Pass `false` to anonymise the open and click events (counted in aggregate statistics only). If it is not passed, the recipient is treated as unknown consent status and the email is still sent (the open and click are anonymised unless your account tracks unknown-consent contacts). A value other than `true`/`false` is rejected. Ignored when the feature is not enabled for your account.
+     */
+    #[JsonProperty('contactPixelTrackingConsent')]
+    public ?bool $contactPixelTrackingConsent;
+
+    /**
      * @var string $email BCC recipient email address
      */
     #[JsonProperty('email')]
@@ -21,6 +27,7 @@ class SendTransacEmailRequestBccItem extends JsonSerializableType
 
     /**
      * @param array{
+     *   contactPixelTrackingConsent?: ?bool,
      *   email: string,
      *   name?: ?string,
      * } $values
@@ -28,6 +35,7 @@ class SendTransacEmailRequestBccItem extends JsonSerializableType
     public function __construct(
         array $values,
     ) {
+        $this->contactPixelTrackingConsent = $values['contactPixelTrackingConsent'] ?? null;
         $this->email = $values['email'];
         $this->name = $values['name'] ?? null;
     }

--- a/src/TransactionalEmails/Types/SendTransacEmailRequestCcItem.php
+++ b/src/TransactionalEmails/Types/SendTransacEmailRequestCcItem.php
@@ -8,6 +8,12 @@ use Brevo\Core\Json\JsonProperty;
 class SendTransacEmailRequestCcItem extends JsonSerializableType
 {
     /**
+     * @var ?bool $contactPixelTrackingConsent Consent of the recipient in cc for open (pixel) and click tracking, resolved by the sender at send time. Considered only if the per-contact pixel tracking consent feature is enabled for your account. Pass `true` if this recipient has consented to open and click tracking, in which case the open pixel and tracked links identify the recipient. Pass `false` to anonymise the open and click events (counted in aggregate statistics only). If it is not passed, the recipient is treated as unknown consent status and the email is still sent (the open and click are anonymised unless your account tracks unknown-consent contacts). A value other than `true`/`false` is rejected. Ignored when the feature is not enabled for your account.
+     */
+    #[JsonProperty('contactPixelTrackingConsent')]
+    public ?bool $contactPixelTrackingConsent;
+
+    /**
      * @var string $email CC recipient email address
      */
     #[JsonProperty('email')]
@@ -21,6 +27,7 @@ class SendTransacEmailRequestCcItem extends JsonSerializableType
 
     /**
      * @param array{
+     *   contactPixelTrackingConsent?: ?bool,
      *   email: string,
      *   name?: ?string,
      * } $values
@@ -28,6 +35,7 @@ class SendTransacEmailRequestCcItem extends JsonSerializableType
     public function __construct(
         array $values,
     ) {
+        $this->contactPixelTrackingConsent = $values['contactPixelTrackingConsent'] ?? null;
         $this->email = $values['email'];
         $this->name = $values['name'] ?? null;
     }

--- a/src/TransactionalEmails/Types/SendTransacEmailRequestMessageVersionsItemBccItem.php
+++ b/src/TransactionalEmails/Types/SendTransacEmailRequestMessageVersionsItemBccItem.php
@@ -8,6 +8,12 @@ use Brevo\Core\Json\JsonProperty;
 class SendTransacEmailRequestMessageVersionsItemBccItem extends JsonSerializableType
 {
     /**
+     * @var ?bool $contactPixelTrackingConsent Consent of the recipient in bcc for open (pixel) and click tracking, resolved by the sender at send time. Considered only if the per-contact pixel tracking consent feature is enabled for your account. Pass `true` if this recipient has consented to open and click tracking, in which case the open pixel and tracked links identify the recipient. Pass `false` to anonymise the open and click events (counted in aggregate statistics only). If it is not passed, the recipient is treated as unknown consent status and the email is still sent (the open and click are anonymised unless your account tracks unknown-consent contacts). A value other than `true`/`false` is rejected. Ignored when the feature is not enabled for your account.
+     */
+    #[JsonProperty('contactPixelTrackingConsent')]
+    public ?bool $contactPixelTrackingConsent;
+
+    /**
      * @var string $email BCC recipient email address
      */
     #[JsonProperty('email')]
@@ -21,6 +27,7 @@ class SendTransacEmailRequestMessageVersionsItemBccItem extends JsonSerializable
 
     /**
      * @param array{
+     *   contactPixelTrackingConsent?: ?bool,
      *   email: string,
      *   name?: ?string,
      * } $values
@@ -28,6 +35,7 @@ class SendTransacEmailRequestMessageVersionsItemBccItem extends JsonSerializable
     public function __construct(
         array $values,
     ) {
+        $this->contactPixelTrackingConsent = $values['contactPixelTrackingConsent'] ?? null;
         $this->email = $values['email'];
         $this->name = $values['name'] ?? null;
     }

--- a/src/TransactionalEmails/Types/SendTransacEmailRequestMessageVersionsItemCcItem.php
+++ b/src/TransactionalEmails/Types/SendTransacEmailRequestMessageVersionsItemCcItem.php
@@ -8,6 +8,12 @@ use Brevo\Core\Json\JsonProperty;
 class SendTransacEmailRequestMessageVersionsItemCcItem extends JsonSerializableType
 {
     /**
+     * @var ?bool $contactPixelTrackingConsent Consent of the recipient in cc for open (pixel) and click tracking, resolved by the sender at send time. Considered only if the per-contact pixel tracking consent feature is enabled for your account. Pass `true` if this recipient has consented to open and click tracking, in which case the open pixel and tracked links identify the recipient. Pass `false` to anonymise the open and click events (counted in aggregate statistics only). If it is not passed, the recipient is treated as unknown consent status and the email is still sent (the open and click are anonymised unless your account tracks unknown-consent contacts). A value other than `true`/`false` is rejected. Ignored when the feature is not enabled for your account.
+     */
+    #[JsonProperty('contactPixelTrackingConsent')]
+    public ?bool $contactPixelTrackingConsent;
+
+    /**
      * @var string $email CC recipient email address
      */
     #[JsonProperty('email')]
@@ -21,6 +27,7 @@ class SendTransacEmailRequestMessageVersionsItemCcItem extends JsonSerializableT
 
     /**
      * @param array{
+     *   contactPixelTrackingConsent?: ?bool,
      *   email: string,
      *   name?: ?string,
      * } $values
@@ -28,6 +35,7 @@ class SendTransacEmailRequestMessageVersionsItemCcItem extends JsonSerializableT
     public function __construct(
         array $values,
     ) {
+        $this->contactPixelTrackingConsent = $values['contactPixelTrackingConsent'] ?? null;
         $this->email = $values['email'];
         $this->name = $values['name'] ?? null;
     }

--- a/src/TransactionalEmails/Types/SendTransacEmailRequestMessageVersionsItemToItem.php
+++ b/src/TransactionalEmails/Types/SendTransacEmailRequestMessageVersionsItemToItem.php
@@ -8,6 +8,12 @@ use Brevo\Core\Json\JsonProperty;
 class SendTransacEmailRequestMessageVersionsItemToItem extends JsonSerializableType
 {
     /**
+     * @var ?bool $contactPixelTrackingConsent Consent of the recipient for open (pixel) and click tracking, resolved by the sender at send time. Considered only if the per-contact pixel tracking consent feature is enabled for your account. Pass `true` if this recipient has consented to open and click tracking, in which case the open pixel and tracked links identify the recipient. Pass `false` to anonymise the open and click events (counted in aggregate statistics only). If it is not passed, the recipient is treated as unknown consent status and the email is still sent (the open and click are anonymised unless your account tracks unknown-consent contacts). A value other than `true`/`false` is rejected. Ignored when the feature is not enabled for your account.
+     */
+    #[JsonProperty('contactPixelTrackingConsent')]
+    public ?bool $contactPixelTrackingConsent;
+
+    /**
      * @var string $email Email address of the recipient
      */
     #[JsonProperty('email')]
@@ -21,6 +27,7 @@ class SendTransacEmailRequestMessageVersionsItemToItem extends JsonSerializableT
 
     /**
      * @param array{
+     *   contactPixelTrackingConsent?: ?bool,
      *   email: string,
      *   name?: ?string,
      * } $values
@@ -28,6 +35,7 @@ class SendTransacEmailRequestMessageVersionsItemToItem extends JsonSerializableT
     public function __construct(
         array $values,
     ) {
+        $this->contactPixelTrackingConsent = $values['contactPixelTrackingConsent'] ?? null;
         $this->email = $values['email'];
         $this->name = $values['name'] ?? null;
     }

--- a/src/TransactionalEmails/Types/SendTransacEmailRequestToItem.php
+++ b/src/TransactionalEmails/Types/SendTransacEmailRequestToItem.php
@@ -8,6 +8,12 @@ use Brevo\Core\Json\JsonProperty;
 class SendTransacEmailRequestToItem extends JsonSerializableType
 {
     /**
+     * @var ?bool $contactPixelTrackingConsent Consent of the recipient for open (pixel) and click tracking, resolved by the sender at send time. Considered only if the per-contact pixel tracking consent feature is enabled for your account. Pass `true` if this recipient has consented to open and click tracking, in which case the open pixel and tracked links identify the recipient. Pass `false` to anonymise the open and click events (counted in aggregate statistics only). If it is not passed, the recipient is treated as unknown consent status and the email is still sent (the open and click are anonymised unless your account tracks unknown-consent contacts). A value other than `true`/`false` is rejected. Ignored when the feature is not enabled for your account.
+     */
+    #[JsonProperty('contactPixelTrackingConsent')]
+    public ?bool $contactPixelTrackingConsent;
+
+    /**
      * @var string $email Email address of the recipient
      */
     #[JsonProperty('email')]
@@ -21,6 +27,7 @@ class SendTransacEmailRequestToItem extends JsonSerializableType
 
     /**
      * @param array{
+     *   contactPixelTrackingConsent?: ?bool,
      *   email: string,
      *   name?: ?string,
      * } $values
@@ -28,6 +35,7 @@ class SendTransacEmailRequestToItem extends JsonSerializableType
     public function __construct(
         array $values,
     ) {
+        $this->contactPixelTrackingConsent = $values['contactPixelTrackingConsent'] ?? null;
         $this->email = $values['email'];
         $this->name = $values['name'] ?? null;
     }


### PR DESCRIPTION
Adds the optional per-recipient `contactPixelTrackingConsent` boolean to the `to`, `cc` and `bcc` items of `POST /v3/smtp/email`, and to the same three recipient lists nested inside `messageVersions`:

- `SendTransacEmailRequestToItem` / `CcItem` / `BccItem`
- `SendTransacEmailRequestMessageVersionsItemToItem` / `CcItem` / `BccItem`

Each is a typed nullable property with a `#[JsonProperty]` attribute, alphabetically ordered, plus the constructor array-shape docblock entry and `?? null` default — mirroring the Fern PHP generator output exactly.

## Verified

- `phpstan` (level max, 996 files) and `phpunit` (75 tests) green both before and after
- `php -l` clean on all six edited files
- Tri-state proven on the wire: `true` → `"contactPixelTrackingConsent":true`, `false` → `false`, and omitted (or PHP `null`) → **key absent**, because `JsonSerializableType::jsonSerialize()` drops null properties never marked explicitly set
- real sends to `api.brevo.com/v3` on prod test account 3143293: `201`, delivered

## Why this is hand-written

This repo is Fern-generated and has not been regenerated since **2026-07-03**, so the field never appeared in the published SDK even though the spec has carried it for weeks. Rather than keep waiting on a `fern generate` run, this is a hand-written stopgap that matches what the generator would emit. **The next `fern generate` will overwrite these files — that is expected and fine**, because the regenerated output contains the same field. **No version bump**: Fern owns versioning.

Six edits, not four: Fern inlines separate recipient copies for `messageVersions`, matching the 6 occurrences in the spec.

## Description wording covers clicks too

Per-contact consent gates **click** links as well as the open pixel — `an=1` is stamped at send time by DTSL/sendmail-personaliser#1231 and consumed by DTSL/redirection#2384, in production since 2026-08-03. The descriptions here reflect that. The matching spec wording update is DTSL/public-api#5895 (legacy client spec + OpenAPI bundle + generated v3, all in one PR). Until it merges this text is ahead of the published spec.

## Related

- Spec: DTSL/public-api#5895 (legacy client spec + OpenAPI bundle + generated v3), earlier bundle PRs #5885 / #5890 / #5892 / #5893, DTSL/public-developer-portal#94
- Sibling SDK PRs: getbrevo/brevo-java#27, getbrevo/brevo-csharp#19, getbrevo/brevo-ruby#17, getbrevo/brevo-go#29

🤖 Generated with [Claude Code](https://claude.com/claude-code)